### PR TITLE
Modifies storage overrides for proposal arrays to account for Tenderly change

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
   },
   "devDependencies": {
     "prettier": "^2.3.2"
+  },
+  "volta": {
+    "node": "18.17.0",
+    "yarn": "1.22.21"
   }
 }

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -152,6 +152,10 @@ async function simulateNew(config: SimulationConfigNew): Promise<SimulationResul
       [`${proposalKey}.forVotes`]: votingTokenSupply.toString(),
       [`${proposalKey}.againstVotes`]: '0',
       [`${proposalKey}.abstainVotes`]: '0',
+      [`${proposalKey}.targets.length`]: targets.length.toString(),
+      [`${proposalKey}.values.length`]: targets.length.toString(),
+      [`${proposalKey}.signatures.length`]: targets.length.toString(),
+      [`${proposalKey}.calldatas.length`]: targets.length.toString(),
     }
 
     targets.forEach((target, i) => {


### PR DESCRIPTION
From Tenderly support:

         > We’ve identified the root cause of the problem. During the refactor of
         > state-encoding logic, we disabled the automatic modification of array lengths,
         > so if you increase the size of the array, you also need to adjust array.length
         > variable.
