### PR TITLE
feat: add proposal caching system to improve performance

### DIFF
--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cache
-          key: ${{ runner.os }}-proposals-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-proposals-${{ hashFiles('**/bun.lockb') }}
           restore-keys: |
             ${{ runner.os }}-proposals-
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cache/abis
-          key: ${{ runner.os }}-abis-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-abis-${{ hashFiles('**/bun.lockb') }}
           restore-keys: |
             ${{ runner.os }}-abis-
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: reports
-          key: ${{ runner.os }}-reports-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-reports-${{ hashFiles('**/bun.lockb') }}
           restore-keys: |
             ${{ runner.os }}-reports-
 

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Install Python dependencies
+      - name: Install Slither dependencies
         run: |
           pip3 install solc-select slither-analyzer
           solc-select install 0.8.19

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Cache proposal simulation results
         uses: actions/cache@v4
         with:
-          path: cache/proposals
+          path: cache
           key: ${{ runner.os }}-proposals-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-proposals-

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -37,10 +37,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-proposals-
 
+      - name: Cache ABIs
+        uses: actions/cache@v4
+        with:
+          path: cache/abis
+          key: ${{ runner.os }}-abis-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-abis-
+
+      - name: Cache reports
+        uses: actions/cache@v4
+        with:
+          path: reports
+          key: ${{ runner.os }}-reports-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-reports-
+
       - name: Install dependencies
         run: bun install
 
-      - name: Install Slither dependencies
+      - name: Install Python dependencies
         run: |
           pip3 install solc-select slither-analyzer
           solc-select install 0.8.19

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -29,6 +29,14 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Cache proposal simulation results
+        uses: actions/cache@v4
+        with:
+          path: cache/proposals
+          key: ${{ runner.os }}-proposals-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-proposals-
+
       - name: Install dependencies
         run: bun install
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ reports/
 # hardhat
 artifacts/
 cache/proposals/
+cache/abis/
 
 # slither
 crytic-export/

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ reports/
 
 # hardhat
 artifacts/
-cache/proposals/
-cache/abis/
+cache/
 
 # slither
 crytic-export/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ reports/
 
 # hardhat
 artifacts/
-cache/
+cache/proposals/
 
 # slither
 crytic-export/

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,8 @@
     "rules": {
       "recommended": true,
       "correctness": {
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       },
       "suspicious": {
         "noExplicitAny": "warn"

--- a/checks/check-decode-calldata.ts
+++ b/checks/check-decode-calldata.ts
@@ -215,13 +215,8 @@ async function prettifyCalldata(
 
   // Try to decode using Etherscan ABI first
   try {
-    console.log(
-      `[DEBUG] Trying to decode using Etherscan ABI for ${target} with selector ${selector}`,
-    );
     const decoded = await decodeFunctionWithAbi(target, call.input as `0x${string}`);
     if (decoded) {
-      console.log(`[DEBUG] Successfully decoded using Etherscan ABI: ${decoded.name}`);
-
       // Cache the decoded function
       decodedFunctionCache[cacheKey] = decoded;
 
@@ -240,7 +235,6 @@ async function prettifyCalldata(
       return description;
     }
 
-    console.log(`[DEBUG] Failed to decode using Etherscan ABI for ${target}`);
     warnings.push(
       `Failed to decode function with selector ${selector} for contract ${target} using Etherscan ABI`,
     );
@@ -254,13 +248,11 @@ async function prettifyCalldata(
   // Handle token-related actions
   const isTokenAction = selector in TOKEN_HANDLERS;
   if (isTokenAction) {
-    console.log(`[DEBUG] Using token handler for selector ${selector}`);
     const { symbol, decimals } = await fetchTokenMetadata(call.to);
     return TOKEN_HANDLERS[selector](call, decimals || 0, symbol, contractIdentifier);
   }
 
   // Generic handling for non-token actions
-  console.log(`[DEBUG] Using generic handling for ${target} with selector ${selector}`);
   const sig = getSignature(call);
   return getDescription(contractIdentifier, sig, call);
 }

--- a/checks/check-decode-calldata.ts
+++ b/checks/check-decode-calldata.ts
@@ -33,7 +33,7 @@ export const checkDecodeCalldata: ProposalCheck = {
         if (!call) {
           // If we can't find the call in the trace, add a warning
           // Skip the warning for ETH transfers which might not appear in the trace
-          if (!(calldata === '0x' && BigInt(proposal.values[i].toString()) > 0n)) {
+          if (!(calldata === '0x' && BigInt(proposal.values?.[i].toString() ?? '0') > 0n)) {
             const msg = `Could not find matching call for target ${proposal.targets[i]} with calldata ${calldata}`;
             warnings.push(msg);
           }
@@ -43,7 +43,7 @@ export const checkDecodeCalldata: ProposalCheck = {
             from: deps.timelock.address,
             to: proposal.targets[i],
             input: calldata,
-            value: proposal.values[i].toString(),
+            value: proposal.values?.[i].toString() ?? '0',
           } as FluffyCall;
         } else {
           // If we found the call, check for subcalls with the same input data

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,6 @@
 'use client';
-
-import { ReportCard } from '@/components/ReportCard';
 import { StructuredReport } from '@/components/StructuredReport';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -14,7 +11,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Toaster } from '@/components/ui/sonner';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { type Proposal, useSimulationResults } from '@/hooks/use-simulation-results';
 import { useWriteProposeNew } from '@/hooks/use-write-propose-new';
 import { AlertTriangleIcon, CheckCircleIcon, InfoIcon } from 'lucide-react';

--- a/frontend/src/components/StructuredReport.tsx
+++ b/frontend/src/components/StructuredReport.tsx
@@ -1,9 +1,7 @@
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type {
   SimulationCheck,
-  SimulationEvent,
   SimulationStateChange,
   StructuredSimulationReport,
 } from '@/hooks/use-simulation-results';
@@ -15,7 +13,6 @@ import {
   ExternalLinkIcon,
   InfoIcon,
 } from 'lucide-react';
-import Link from 'next/link';
 import type React from 'react';
 import { useMemo, useState } from 'react';
 

--- a/index.ts
+++ b/index.ts
@@ -14,9 +14,9 @@ import type {
   SimulationConfigBase,
   SimulationData,
 } from './types';
+import { cacheProposal, getCachedProposal, needsSimulation } from './utils/cache/proposalCache';
 import { provider } from './utils/clients/ethers';
 import { simulate } from './utils/clients/tenderly';
-import { cacheProposal, getCachedProposal, needsSimulation } from './utils/cache/proposalCache';
 import { DAO_NAME, GOVERNOR_ADDRESS, SIM_NAME } from './utils/constants';
 import {
   formatProposalId,
@@ -85,12 +85,17 @@ async function main() {
 
     // Filter proposals that need simulation based on cache status
     const proposalsToSimulate = simProposals.filter((simProposal) =>
-      needsSimulation(DAO_NAME, GOVERNOR_ADDRESS, simProposal.id.toString(), simProposal.state),
+      needsSimulation(DAO_NAME!, GOVERNOR_ADDRESS!, simProposal.id.toString(), simProposal.state),
     );
 
     const cachedProposals = simProposals.filter(
       (simProposal) =>
-        !needsSimulation(DAO_NAME, GOVERNOR_ADDRESS, simProposal.id.toString(), simProposal.state),
+        !needsSimulation(
+          DAO_NAME!,
+          GOVERNOR_ADDRESS!,
+          simProposal.id.toString(),
+          simProposal.state,
+        ),
     );
 
     // Load cached proposals

--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,10 @@
  * @notice Entry point for executing a single proposal against a forked mainnet
  */
 
+import { existsSync } from 'node:fs';
 import { getAddress } from '@ethersproject/address';
 import type { Contract } from 'ethers';
 import type { BigNumber } from 'ethers';
-import { existsSync } from 'node:fs';
 import ALL_CHECKS from './checks';
 import { generateAndSaveReports } from './presentation/report';
 import type {

--- a/index.ts
+++ b/index.ts
@@ -85,17 +85,22 @@ async function main() {
 
     // Filter proposals that need simulation based on cache status
     const proposalsToSimulate = simProposals.filter((simProposal) =>
-      needsSimulation(DAO_NAME!, GOVERNOR_ADDRESS!, simProposal.id.toString(), simProposal.state),
+      needsSimulation({
+        daoName: DAO_NAME!,
+        governorAddress: GOVERNOR_ADDRESS!,
+        proposalId: simProposal.id.toString(),
+        currentState: simProposal.state,
+      }),
     );
 
     const cachedProposals = simProposals.filter(
       (simProposal) =>
-        !needsSimulation(
-          DAO_NAME!,
-          GOVERNOR_ADDRESS!,
-          simProposal.id.toString(),
-          simProposal.state,
-        ),
+        !needsSimulation({
+          daoName: DAO_NAME!,
+          governorAddress: GOVERNOR_ADDRESS!,
+          proposalId: simProposal.id.toString(),
+          currentState: simProposal.state,
+        }),
     );
 
     // Load cached proposals
@@ -108,7 +113,7 @@ async function main() {
       );
 
       if (cachedData) {
-        simOutputs.push(cachedData.simulationData);
+        simOutputs.push(cachedData);
       }
     }
 
@@ -188,12 +193,10 @@ async function main() {
 
     // Generate markdown report.
     const [startBlock, endBlock] = await Promise.all([
-      proposal.startBlock.toNumber() <= latestBlock.number
-        ? provider.getBlock(proposal.startBlock.toNumber())
+      proposal.startBlock <= latestBlock.number
+        ? provider.getBlock(Number(proposal.startBlock))
         : null,
-      proposal.endBlock.toNumber() <= latestBlock.number
-        ? provider.getBlock(proposal.endBlock.toNumber())
-        : null,
+      proposal.endBlock <= latestBlock.number ? provider.getBlock(Number(proposal.endBlock)) : null,
     ]);
 
     // Save markdown report to a file.

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { getAddress } from '@ethersproject/address';
 import type { Contract } from 'ethers';
 import type { BigNumber } from 'ethers';
 import ALL_CHECKS from './checks';
-import { generateAndSaveReports, writeFrontendData } from './presentation/report';
+import { generateAndSaveReports } from './presentation/report';
 import type {
   AllCheckResults,
   GovernorType,

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -16,7 +16,6 @@ import { visit } from 'unist-util-visit';
 import type { Visitor } from 'unist-util-visit';
 import type {
   AllCheckResults,
-  FrontendData,
   GovernorType,
   ProposalEvent,
   SimulationCalldata,
@@ -286,6 +285,71 @@ function generateStructuredReport(
 }
 
 /**
+ * @notice Write simulation results to frontend public directory for easy access
+ * @param governorType The type of governor contract
+ * @param blocks The relevant blocks for the proposal
+ * @param proposal The proposal details
+ * @param checks The check results
+ * @param markdownReport The full markdown report
+ */
+export function writeFrontendData(
+  governorType: GovernorType,
+  blocks: { current: Block; start: Block | null; end: Block | null },
+  proposal: ProposalEvent,
+  checks: AllCheckResults,
+  markdownReport: string,
+) {
+  // Only write frontend data if we're in proposal creation mode (SIM_NAME is set)
+  if (!process.env.SIM_NAME) {
+    return;
+  }
+
+  try {
+    // Extract the proposal data in the format expected by the frontend
+    const id = formatProposalId(governorType, proposal.id!);
+    const proposalData = {
+      id,
+      targets: proposal.targets.map((target) => target as `0x${string}`),
+      values: (proposal.values || []).map((value) => BigInt(value.toString())),
+      signatures: proposal.signatures,
+      calldatas: proposal.calldatas.map((data) => data as `0x${string}`),
+      description: proposal.description,
+    };
+
+    // Generate the structured report
+    const structuredReport = generateStructuredReport(governorType, blocks, proposal, checks);
+
+    // Create a simplified report structure for the frontend
+    const reportForFrontend = {
+      status: structuredReport.status,
+      summary: structuredReport.summary,
+      markdownReport,
+      structuredReport,
+    };
+
+    // Use the correct path to the frontend/public directory
+    const projectRoot = join(__dirname, '..');
+    const frontendPublicDir = join(projectRoot, 'frontend', 'public');
+
+    // Create the directory if it doesn't exist
+    if (!existsSync(frontendPublicDir)) {
+      mkdirSync(frontendPublicDir, { recursive: true });
+    }
+
+    // Write the frontend data
+    writeFileSync(
+      join(frontendPublicDir, 'simulation-results.json'),
+      JSON.stringify([{ proposalData, report: reportForFrontend }], (_, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      ),
+    );
+    console.log('Frontend data written for proposal creation');
+  } catch (error) {
+    console.error('Error writing frontend data:', error);
+  }
+}
+
+/**
  * Generates the proposal report and saves Markdown, PDF, and HTML versions of it.
  * Also writes the report data to the frontend/public directory for easy access.
  * @param blocks the relevant blocks for the proposal.
@@ -340,34 +404,8 @@ export async function generateAndSaveReports(
     ),
   ]);
 
-  // Also write the report data to the frontend/public directory
-  try {
-    // Extract the proposal data in the format expected by the frontend
-    const proposalData = {
-      id: id,
-      targets: proposal.targets.map((target) => target as `0x${string}`),
-      values: (proposal.values || []).map((value) => BigInt(value.toString())),
-      signatures: proposal.signatures,
-      calldatas: proposal.calldatas.map((data) => data as `0x${string}`),
-      description: proposal.description,
-    };
-
-    // Generate the structured report
-    const structuredReport = generateStructuredReport(governorType, blocks, proposal, checks);
-
-    // Create a simplified report structure for the frontend
-    const reportForFrontend = {
-      status: structuredReport.status,
-      summary: structuredReport.summary,
-      markdownReport, // Include the full markdown report
-      structuredReport, // Include the structured report
-    };
-
-    // Write the frontend data
-    writeFrontendData([{ proposalData, report: reportForFrontend }]);
-  } catch (error) {
-    console.error('Error writing frontend data:', error);
-  }
+  // Write frontend data if in proposal creation mode
+  writeFrontendData(governorType, blocks, proposal, checks, markdownReport);
 }
 
 /**
@@ -443,33 +481,4 @@ function remarkFixEmojiLinks() {
       }
     }) as Visitor<Link>);
   };
-}
-
-/*
- * @notice Write simulation results to frontend public directory for easy access
- * @param data The data to write to the frontend, containing proposalData and report
- */
-export function writeFrontendData(data: FrontendData[]) {
-  try {
-    // Use the correct path to the frontend/public directory
-    const projectRoot = join(__dirname, '..');
-    const frontendPublicDir = join(projectRoot, 'frontend', 'public');
-
-    // Create the directory if it doesn't exist
-    if (!existsSync(frontendPublicDir)) {
-      mkdirSync(frontendPublicDir, { recursive: true });
-      console.log(`Created directory: ${frontendPublicDir}`);
-    }
-
-    // Write the frontend data
-    writeFileSync(
-      join(frontendPublicDir, 'simulation-results.json'),
-      JSON.stringify(data, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2),
-    );
-    console.log(
-      `Simulation results written to ${join(frontendPublicDir, 'simulation-results.json')}`,
-    );
-  } catch (error) {
-    console.error('Error writing frontend data:', error);
-  }
 }

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -22,7 +22,6 @@ import type {
   ProposalEvent,
   SimulationCalldata,
   SimulationCheck,
-  SimulationData,
   SimulationEvent,
   SimulationStateChange,
   StructuredSimulationReport,

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -2,7 +2,6 @@ import fs, { promises as fsp, writeFileSync } from 'node:fs';
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Block } from '@ethersproject/abstract-provider';
-import type { BigNumber } from 'ethers';
 import { mdToPdf } from 'md-to-pdf';
 import type { Link, Root } from 'mdast';
 import rehypeSanitize from 'rehype-sanitize';
@@ -121,9 +120,9 @@ function formatTime(blockTimestamp: number): string {
  * @param current the current block
  * @param block the future block number
  */
-function estimateTime(current: Block, block: BigNumber): number {
-  if (block.lt(current.number)) throw new Error('end block is less than current');
-  return block.sub(current.number).mul(13).add(current.timestamp).toNumber();
+function estimateTime(current: Block, block: bigint): number {
+  if (block < BigInt(current.number)) throw new Error('end block is less than current');
+  return Number(block - BigInt(current.number)) * 13 + current.timestamp;
 }
 
 /**
@@ -397,7 +396,7 @@ _Updated as of block [${blocks.current.number}](https://etherscan.io/block/${blo
 - Proposer: ${toAddressLink(proposer)}
 - Start Block: ${startBlock} (${
     blocks.start
-      ? formatTime(blocks.start.timestamp)
+      ? formatTime(Number(blocks.start.timestamp))
       : formatTime(estimateTime(blocks.current, startBlock))
   })
 - End Block: ${endBlock} (${

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -347,7 +347,7 @@ export async function generateAndSaveReports(
     const proposalData = {
       id: id,
       targets: proposal.targets.map((target) => target as `0x${string}`),
-      values: proposal.values.map((value) => BigInt(value.toString())),
+      values: (proposal.values || []).map((value) => BigInt(value.toString())),
       signatures: proposal.signatures,
       calldatas: proposal.calldatas.map((data) => data as `0x${string}`),
       description: proposal.description,

--- a/run-checks.ts
+++ b/run-checks.ts
@@ -6,7 +6,7 @@ import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
 import ALL_CHECKS from './checks';
 import { generateAndSaveReports } from './presentation/report';
-import type { AllCheckResults, GovernorType, SimulationConfig } from './types';
+import type { AllCheckResults, SimulationConfig } from './types';
 import { provider } from './utils/clients/ethers';
 import { simulate } from './utils/clients/tenderly';
 import { DAO_NAME, GOVERNOR_ADDRESS } from './utils/constants';

--- a/run-checks.ts
+++ b/run-checks.ts
@@ -81,12 +81,10 @@ async function main() {
   // Generate markdown report
   console.log('Generating report...');
   const [startBlock, endBlock] = await Promise.all([
-    proposal.startBlock.toNumber() <= latestBlock.number
-      ? provider.getBlock(proposal.startBlock.toNumber())
+    proposal.startBlock <= latestBlock.number
+      ? provider.getBlock(Number(proposal.startBlock))
       : null,
-    proposal.endBlock.toNumber() <= latestBlock.number
-      ? provider.getBlock(proposal.endBlock.toNumber())
-      : null,
+    proposal.endBlock <= latestBlock.number ? provider.getBlock(Number(proposal.endBlock)) : null,
   ]);
 
   // Save markdown report to a file

--- a/types.d.ts
+++ b/types.d.ts
@@ -76,14 +76,14 @@ export interface ProposalStruct {
 }
 
 export interface ProposalEvent {
-  id?: BigNumber; // Bravo governor
-  proposalId?: BigNumber; // OZ governor
+  id: bigint;
+  proposalId: bigint;
   proposer: string;
-  startBlock: BigNumber;
-  endBlock: BigNumber;
+  startBlock: bigint;
+  endBlock: bigint;
   description: string;
   targets: string[];
-  values: BigNumber[];
+  values: bigint[] | undefined;
   signatures: string[];
   calldatas: string[];
 }

--- a/utils/cache/proposalCache.ts
+++ b/utils/cache/proposalCache.ts
@@ -2,8 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { BigNumber } from 'ethers';
 import type { SimulationData } from '../../types';
-import { PROPOSAL_STATES } from '../contracts/governor-bravo';
-import type { NeedsSimulationParams, ProposalCacheEntry } from './types';
+import type { ProposalCacheEntry } from './types';
 
 // Cache directory path - use GITHUB_WORKSPACE in CI, process.cwd() locally
 const CACHE_DIR = process.env.GITHUB_WORKSPACE || process.cwd();

--- a/utils/cache/proposalCache.ts
+++ b/utils/cache/proposalCache.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { BigNumber } from 'ethers';
+import type { SimulationData } from '../../types';
 import { PROPOSAL_STATES } from '../contracts/governor-bravo';
 import type { NeedsSimulationParams, ProposalCacheEntry } from './types';
 
@@ -68,7 +69,7 @@ export function cacheProposal(
   governorAddress: string,
   proposalId: string,
   proposalState: string | null,
-  simulationData: any,
+  simulationData: SimulationData,
 ): void {
   const cachePath = getCacheFilePath(daoName, governorAddress, proposalId);
   try {

--- a/utils/cache/proposalCache.ts
+++ b/utils/cache/proposalCache.ts
@@ -1,0 +1,183 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { SimulationData, SimulationResult } from '../../types';
+import { PROPOSAL_STATES } from '../contracts/governor-bravo';
+
+// Define the cache directory
+const CACHE_DIR = join(process.cwd(), 'cache', 'proposals');
+
+// Define the cache entry type
+interface ProposalCacheEntry {
+  timestamp: number;
+  proposalState: string | null;
+  simulationData: SimulationData;
+}
+
+/**
+ * Ensures the cache directory exists
+ */
+function ensureCacheDirectory(): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    console.log(`Created cache directory: ${CACHE_DIR}`);
+  }
+}
+
+/**
+ * Generates a cache key for a proposal
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @returns The cache key
+ */
+function getCacheKey(daoName: string, governorAddress: string, proposalId: string): string {
+  return `${daoName}-${governorAddress.toLowerCase()}-${proposalId}`;
+}
+
+/**
+ * Gets the path to the cache file for a proposal
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @returns The path to the cache file
+ */
+function getCacheFilePath(daoName: string, governorAddress: string, proposalId: string): string {
+  const cacheKey = getCacheKey(daoName, governorAddress, proposalId);
+  return join(CACHE_DIR, `${cacheKey}.json`);
+}
+
+/**
+ * Checks if a proposal simulation is cached
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @returns True if the proposal is cached, false otherwise
+ */
+export function isProposalCached(
+  daoName: string,
+  governorAddress: string,
+  proposalId: string,
+): boolean {
+  const cacheFilePath = getCacheFilePath(daoName, governorAddress, proposalId);
+  return existsSync(cacheFilePath);
+}
+
+/**
+ * Gets a cached proposal simulation
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @returns The cached simulation data or null if not found
+ */
+export function getCachedProposal(
+  daoName: string,
+  governorAddress: string,
+  proposalId: string,
+): ProposalCacheEntry | null {
+  try {
+    const cacheFilePath = getCacheFilePath(daoName, governorAddress, proposalId);
+    if (!existsSync(cacheFilePath)) {
+      return null;
+    }
+
+    const cacheData = readFileSync(cacheFilePath, 'utf-8');
+    return JSON.parse(cacheData) as ProposalCacheEntry;
+  } catch (error) {
+    console.error(`Error reading cache for proposal ${proposalId}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Caches a proposal simulation
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @param proposalState The current state of the proposal
+ * @param simulationData The simulation data to cache
+ */
+export function cacheProposal(
+  daoName: string,
+  governorAddress: string,
+  proposalId: string,
+  proposalState: string | null,
+  simulationData: SimulationData,
+): void {
+  try {
+    ensureCacheDirectory();
+
+    const cacheFilePath = getCacheFilePath(daoName, governorAddress, proposalId);
+    const cacheEntry: ProposalCacheEntry = {
+      timestamp: Date.now(),
+      proposalState: proposalState || 'Unknown',
+      simulationData,
+    };
+
+    // Convert BigNumber objects to strings for JSON serialization
+    const serializedEntry = JSON.stringify(cacheEntry, (_, value) => {
+      if (typeof value === 'object' && value !== null && typeof value.toHexString === 'function') {
+        return value.toString();
+      }
+      return value;
+    });
+
+    writeFileSync(cacheFilePath, serializedEntry);
+    console.log(`Cached simulation for proposal ${proposalId}`);
+  } catch (error) {
+    console.error(`Error caching proposal ${proposalId}:`, error);
+  }
+}
+
+/**
+ * Determines if a proposal needs to be simulated based on its current state and cache status
+ * @param daoName The name of the DAO
+ * @param governorAddress The address of the governor contract
+ * @param proposalId The ID of the proposal
+ * @param currentState The current state of the proposal
+ * @returns True if the proposal needs simulation, false otherwise
+ */
+export function needsSimulation(
+  daoName: string,
+  governorAddress: string,
+  proposalId: string,
+  currentState: string | null,
+): boolean {
+  // If state is null, we need to simulate
+  if (currentState === null) {
+    return true;
+  }
+
+  // Always simulate if not cached
+  if (!isProposalCached(daoName, governorAddress, proposalId)) {
+    return true;
+  }
+
+  // Get the cached entry
+  const cachedEntry = getCachedProposal(daoName, governorAddress, proposalId);
+  if (!cachedEntry) {
+    return true;
+  }
+
+  // If the proposal state has changed, we need to simulate again
+  if (cachedEntry.proposalState !== currentState) {
+    return true;
+  }
+
+  // If the proposal is in a terminal state (Executed, Defeated, Expired, Canceled),
+  // we don't need to simulate again
+  const terminalStates = [
+    PROPOSAL_STATES['7'], // Executed
+    PROPOSAL_STATES['3'], // Defeated
+    PROPOSAL_STATES['6'], // Expired
+    PROPOSAL_STATES['2'], // Canceled
+  ];
+
+  if (terminalStates.includes(currentState)) {
+    return false;
+  }
+
+  // For active proposals, we might want to re-simulate periodically
+  // For now, we'll re-simulate if the cache is older than 1 hour
+  const ONE_HOUR = 60 * 60 * 1000;
+  return Date.now() - cachedEntry.timestamp > ONE_HOUR;
+}

--- a/utils/cache/proposalCache.ts
+++ b/utils/cache/proposalCache.ts
@@ -52,7 +52,20 @@ export function getCachedProposal(
   try {
     if (existsSync(cachePath)) {
       const data = readFileSync(cachePath, 'utf8');
-      return JSON.parse(data);
+      const parsed = JSON.parse(data);
+
+      // Convert string values back to BigNumber objects
+      if (parsed.simulationData?.proposal) {
+        const proposal = parsed.simulationData.proposal;
+        if (proposal.startBlock) proposal.startBlock = BigNumber.from(proposal.startBlock);
+        if (proposal.endBlock) proposal.endBlock = BigNumber.from(proposal.endBlock);
+        if (proposal.id) proposal.id = BigNumber.from(proposal.id);
+        if (proposal.proposalId) proposal.proposalId = BigNumber.from(proposal.proposalId);
+        if (proposal.values)
+          proposal.values = proposal.values.map((v: string) => BigNumber.from(v));
+      }
+
+      return parsed;
     }
   } catch (error) {
     console.warn(`Error reading cache for proposal ${proposalId}:`, error);

--- a/utils/cache/types.ts
+++ b/utils/cache/types.ts
@@ -1,0 +1,12 @@
+export interface ProposalCacheEntry {
+  timestamp: number;
+  proposalState: string | null;
+  simulationData: any;
+}
+
+export type NeedsSimulationParams = {
+  daoName: string;
+  governorAddress: string;
+  proposalId: string;
+  currentState: string | null;
+};

--- a/utils/cache/types.ts
+++ b/utils/cache/types.ts
@@ -1,9 +1,30 @@
 import type { SimulationData } from '../../types';
 
+export interface CachedProposalEvent {
+  startBlock: string;
+  endBlock: string;
+  id: string;
+  proposalId: string;
+  values: string[];
+  targets: string[];
+  proposer: string;
+  description: string;
+  signatures: string[];
+  calldatas: string[];
+}
+
+export interface CachedSimulationData {
+  proposal: CachedProposalEvent;
+  config: SimulationData['config'];
+  sim: SimulationData['sim'];
+  deps: SimulationData['deps'];
+  latestBlock: SimulationData['latestBlock'];
+}
+
 export interface ProposalCacheEntry {
   timestamp: number;
   proposalState: string | null;
-  simulationData: SimulationData;
+  simulationData: CachedSimulationData;
 }
 
 export type NeedsSimulationParams = {

--- a/utils/cache/types.ts
+++ b/utils/cache/types.ts
@@ -1,7 +1,9 @@
+import type { SimulationData } from '../../types';
+
 export interface ProposalCacheEntry {
   timestamp: number;
   proposalState: string | null;
-  simulationData: any;
+  simulationData: SimulationData;
 }
 
 export type NeedsSimulationParams = {

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -504,6 +504,8 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
     ...(proposalCreatedEvent.args as unknown as ProposalEvent),
     values, // This does not get included otherwise, same reason why we use `proposalCreatedEvent.args![3]` above.
     id: BigNumber.from(proposalId), // Make sure we always have an ID field
+    startBlock: BigNumber.from(proposalCreatedEvent.args?.startBlock),
+    endBlock: BigNumber.from(proposalCreatedEvent.args?.endBlock),
   };
 
   // Handle ETH transfers if needed

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -105,14 +105,14 @@ export async function simulateNew(config: SimulationConfigNew): Promise<Simulati
 
   const startBlock = BigNumber.from(latestBlock.number - 100); // arbitrarily subtract 100
   const proposal: ProposalEvent = {
-    id: proposalId, // Bravo governor
-    proposalId, // OZ governor (for simplicity we just include both ID formats)
+    id: proposalId.toBigInt(), // Bravo governor
+    proposalId: proposalId.toBigInt(), // OZ governor (for simplicity we just include both ID formats)
     proposer: DEFAULT_FROM,
-    startBlock,
-    endBlock: startBlock.add(1),
+    startBlock: startBlock.toBigInt(),
+    endBlock: startBlock.add(1).toBigInt(),
     description,
     targets,
-    values: values.map(BigNumber.from),
+    values: values.map((v) => BigNumber.from(v).toBigInt()),
     signatures,
     calldatas,
   };
@@ -126,7 +126,7 @@ export async function simulateNew(config: SimulationConfigNew): Promise<Simulati
   const from = DEFAULT_FROM;
 
   // Run simulation at the block right after the proposal ends.
-  const simBlock = proposal.endBlock!.add(1);
+  const simBlock = BigNumber.from(proposal.endBlock).add(1);
 
   // For OZ governors we arbitrarily choose execution time. For Bravo governors, we
   // compute the approximate earliest possible execution time based on governance parameters. This
@@ -502,10 +502,10 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
 
   const formattedProposal: ProposalEvent = {
     ...(proposalCreatedEvent.args as unknown as ProposalEvent),
-    values, // This does not get included otherwise, same reason why we use `proposalCreatedEvent.args![3]` above.
-    id: BigNumber.from(proposalId), // Make sure we always have an ID field
-    startBlock: BigNumber.from(proposalCreatedEvent.args?.startBlock),
-    endBlock: BigNumber.from(proposalCreatedEvent.args?.endBlock),
+    values: values.map((v) => v.toBigInt()), // This does not get included otherwise, same reason why we use `proposalCreatedEvent.args![3]` above.
+    id: BigNumber.from(proposalId).toBigInt(), // Make sure we always have an ID field
+    startBlock: BigNumber.from(proposalCreatedEvent.args?.startBlock).toBigInt(),
+    endBlock: BigNumber.from(proposalCreatedEvent.args?.endBlock).toBigInt(),
   };
 
   // Handle ETH transfers if needed
@@ -587,9 +587,9 @@ async function simulateExecuted(config: SimulationConfigExecuted): Promise<Simul
 
   const formattedProposal: ProposalEvent = {
     ...proposal,
-    id: BigNumber.from(proposalId), // Make sure we always have an ID field
-    startBlock: BigNumber.from(proposal.startBlock),
-    endBlock: BigNumber.from(proposal.endBlock),
+    id: BigNumber.from(proposalId).toBigInt(), // Make sure we always have an ID field
+    startBlock: BigNumber.from(proposal.startBlock).toBigInt(),
+    endBlock: BigNumber.from(proposal.endBlock).toBigInt(),
   };
   const deps: ProposalData = {
     governor,

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -588,6 +588,8 @@ async function simulateExecuted(config: SimulationConfigExecuted): Promise<Simul
   const formattedProposal: ProposalEvent = {
     ...proposal,
     id: BigNumber.from(proposalId), // Make sure we always have an ID field
+    startBlock: BigNumber.from(proposal.startBlock),
+    endBlock: BigNumber.from(proposal.endBlock),
   };
   const deps: ProposalData = {
     governor,

--- a/utils/contracts/governor.ts
+++ b/utils/contracts/governor.ts
@@ -111,7 +111,9 @@ export async function getProposalIds(
 
     // Remove proposals from GovernorAlpha based on the initial GovernorBravo proposal ID
     const initialProposalId = await governor.initialProposalId();
-    return allProposalIds.filter((id) => id.gt(initialProposalId));
+    return allProposalIds
+      .filter((id) => BigNumber.from(id).gt(initialProposalId))
+      .map((id) => BigNumber.from(id));
   }
 
   const governor = governorOz(address);
@@ -120,13 +122,15 @@ export async function getProposalIds(
     0,
     latestBlockNum,
   );
-  return proposalCreatedLogs.map((logs) => (logs.args as unknown as ProposalEvent).proposalId!);
+  return proposalCreatedLogs.map((logs) =>
+    BigNumber.from((logs.args as unknown as ProposalEvent).proposalId!),
+  );
 }
 
 export function getProposalId(proposal: ProposalEvent): BigNumber {
   const id = proposal.id || proposal.proposalId;
   if (!id) throw new Error(`Proposal ID not found for proposal: ${JSON.stringify(proposal)}`);
-  return id;
+  return BigNumber.from(id);
 }
 
 // Generate proposal ID, used when simulating new proposals.


### PR DESCRIPTION
# Implement Proposal Simulation Caching

When running bulk checks in CI, we were re-simulating proposals unnecessarily, even when their onchain state hadn't changed. This pr drastically reduces calls to the tenderly and etherscan api's, as well as writing reports, and makes the governance checks more scalable.

This pr implements a caching system that stores:
- Simulation results
- Check results
- Generated reports

Cache is invalidated when:
- Proposal's on-chain state changes
- No cached data exists for the proposal
- Reports are missing for cached simulations

## Testing
Tested locally by running `bun start` and ensuring correct cache invalidation and report generation for all proposals.