### PR TITLE
fix: increase Puppeteer timeout to prevent CI failures

### DIFF
--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -462,6 +462,10 @@ export async function generateAndSaveReports(
         dest: `${path}.pdf`,
         launch_options: {
           args: process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+          timeout: 60000, // Increase timeout to 60 seconds
+        },
+        pdf_options: {
+          timeout: 60000, // Increase timeout to 60 seconds
         },
       },
     ),


### PR DESCRIPTION
## Summary
- Increases PDF generation timeout from 30s to 60s to prevent TimeoutError in CI environments
- Adds timeout configuration to both `launch_options` and `pdf_options` in md-to-pdf

## Context
The CI runs were failing with:
```
TimeoutError: Navigation timeout of 30000 ms exceeded
```

This occurs when generating PDF reports for governance proposals. The default 30-second timeout is insufficient for larger reports in CI environments.

## Test plan
- [x] CI should pass without timeout errors
- [x] PDF generation should complete successfully for all governance reports

🤖 Generated with [Claude Code](https://claude.ai/code)