### PR TITLE
feat: separate simulation and proposal timing in metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cd checks && bun test` - Run all tests in checks directory
 - `cd checks && bun test <test-file>` - Run specific test file
 
+**Running Specific Proposals:**
+- `bun run check-proposal <proposal-id>` - Run checks on specific proposal using environment variables
+- `./run-proposal.sh <proposal-id>` - Run checks on specific Uniswap proposal (sets DAO_NAME and GOVERNOR_ADDRESS)
+- `DAO_NAME=<dao> GOVERNOR_ADDRESS=<address> bun run-checks.ts <proposal-id>` - Run checks on specific proposal with custom DAO
+
 ## Architecture Overview
 
 This is a governance safety tool that simulates on-chain proposals and runs safety checks against them.

--- a/index.ts
+++ b/index.ts
@@ -125,8 +125,10 @@ async function main() {
       proposal,
       mainnetResults,
       dir,
+      config.governorAddress,
       finalResult.destinationSimulations,
       destinationChecks,
+      finalResult.executor,
     );
     console.log(`[Index] Reports saved for ${SIM_NAME}.`);
   } else {
@@ -274,7 +276,17 @@ async function main() {
 
         // Generate reports immediately
         const dir = `./reports/${config.daoName}/${config.governorAddress}`;
-        await generateAndSaveReports(governorType, blocks, proposal, checkResults, dir);
+        await generateAndSaveReports(
+          governorType,
+          blocks,
+          proposal,
+          checkResults,
+          dir,
+          config.governorAddress,
+          undefined,
+          undefined,
+          simulationData.executor,
+        );
 
         // Cache everything together
         simulationData.checkResults = checkResults;

--- a/index.ts
+++ b/index.ts
@@ -129,6 +129,8 @@ async function main() {
       finalResult.destinationSimulations,
       destinationChecks,
       finalResult.executor,
+      finalResult.proposalCreatedBlock,
+      finalResult.proposalExecutedBlock,
     );
     console.log(`[Index] Reports saved for ${SIM_NAME}.`);
   } else {
@@ -286,6 +288,8 @@ async function main() {
           undefined,
           undefined,
           simulationData.executor,
+          simulationData.proposalCreatedBlock,
+          simulationData.proposalExecutedBlock,
         );
 
         // Cache everything together

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -1,6 +1,6 @@
 import fs, { promises as fsp, writeFileSync } from 'node:fs';
 import { existsSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { mdToPdf } from 'md-to-pdf';
 import type { Link, Root } from 'mdast';
 import rehypeSanitize from 'rehype-sanitize';
@@ -166,6 +166,8 @@ function generateStructuredReport(
   blocks: { current: SimulationBlock; start: SimulationBlock | null; end: SimulationBlock | null },
   proposal: ProposalEvent,
   checks: AllCheckResults,
+  governorAddress: string,
+  executor?: string,
 ): StructuredSimulationReport {
   // Extract title and proposal text
   const title = getProposalTitle(proposal.description.trim());
@@ -334,32 +336,35 @@ function generateStructuredReport(
       timestamp: blocks.current.timestamp.toString(),
       proposalId: formatProposalId(governorType, proposal.id!),
       proposer: proposal.proposer,
+      governorAddress,
+      executor,
     },
   };
 }
 
 /**
- * @notice Write simulation results to frontend public directory for easy access
+ * @notice Write simulation results JSON file for frontend or GitHub app consumption
  * @param governorType The type of governor contract
  * @param blocks The relevant blocks for the proposal
  * @param proposal The proposal details
  * @param checks The check results
  * @param markdownReport The full markdown report
+ * @param governorAddress The governor contract address
+ * @param outputPath The path where to write the simulation-results.json file
  * @param destinationSimulations Optional destination simulations
+ * @param executor Optional executor address for executed proposals
  */
-export function writeFrontendData(
+export function writeSimulationResultsJson(
   governorType: GovernorType,
   blocks: { current: SimulationBlock; start: SimulationBlock | null; end: SimulationBlock | null },
   proposal: ProposalEvent,
   checks: AllCheckResults,
   markdownReport: string,
+  governorAddress: string,
+  outputPath: string,
   destinationSimulations?: SimulationResult['destinationSimulations'],
+  executor?: string,
 ) {
-  // Only write frontend data if we're in proposal creation mode (SIM_NAME is set)
-  if (!process.env.SIM_NAME) {
-    return;
-  }
-
   try {
     // Extract the proposal data in the format expected by the frontend
     const id = formatProposalId(governorType, proposal.id!);
@@ -373,7 +378,14 @@ export function writeFrontendData(
     };
 
     // Generate the structured report
-    const structuredReport = generateStructuredReport(governorType, blocks, proposal, checks);
+    const structuredReport = generateStructuredReport(
+      governorType,
+      blocks,
+      proposal,
+      checks,
+      governorAddress,
+      executor,
+    );
 
     // Create a simplified report structure for the frontend
     const reportForFrontend = {
@@ -383,28 +395,27 @@ export function writeFrontendData(
       structuredReport,
     };
 
-    // Use the correct path to the frontend/public directory
-    const projectRoot = join(__dirname, '..');
-    const frontendPublicDir = join(projectRoot, 'frontend', 'public');
-
     // Create the directory if it doesn't exist
-    if (!existsSync(frontendPublicDir)) {
-      mkdirSync(frontendPublicDir, { recursive: true });
+    const outputDir = dirname(outputPath);
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true });
     }
 
-    // Write the frontend data
+    // Write the simulation results JSON
     writeFileSync(
-      join(frontendPublicDir, 'simulation-results.json'),
-      JSON.stringify([{ proposalData, report: reportForFrontend }], (_, value) =>
+      outputPath,
+      JSON.stringify({ proposalData, report: reportForFrontend }, (_, value) =>
         typeof value === 'bigint' ? value.toString() : value,
       ),
     );
-    console.log('Frontend data written for proposal creation');
+    console.log(`Simulation results JSON written to: ${outputPath}`);
 
-    // TODO: Potentially add destinationSimulations data to the frontend JSON if needed
-    console.log('[Frontend Data] Destination Sims: ', destinationSimulations); // Log for now
+    // TODO: Potentially add destinationSimulations data if needed
+    if (destinationSimulations && destinationSimulations.length > 0) {
+      console.log('[Frontend Data] Destination Sims: ', destinationSimulations.length);
+    }
   } catch (error) {
-    console.error('Error writing frontend data:', error);
+    console.error('Error writing simulation results JSON:', error);
   }
 }
 
@@ -424,8 +435,10 @@ export async function generateAndSaveReports(
   proposal: ProposalEvent,
   checks: AllCheckResults,
   outputDir: string,
+  governorAddress: string,
   destinationSimulations?: SimulationResult['destinationSimulations'],
   destinationChecks?: Record<number, AllCheckResults>,
+  executor?: string,
 ) {
   console.log(`[Report] Generating report for proposal ${proposal.id} (${proposal.proposalId})`);
   console.log(`[Report] Output directory: ${outputDir}`);
@@ -462,7 +475,14 @@ export async function generateAndSaveReports(
   );
 
   // Generate the structured report for JSON output
-  const structuredReport = generateStructuredReport(governorType, blocks, proposal, checks);
+  const structuredReport = generateStructuredReport(
+    governorType,
+    blocks,
+    proposal,
+    checks,
+    governorAddress,
+    executor,
+  );
 
   // Save off all reports. The Markdown and PDF reports use the `markdownReport`.
   await Promise.all([
@@ -484,8 +504,22 @@ export async function generateAndSaveReports(
     ),
   ]);
 
-  // Write frontend data if in proposal creation mode
-  writeFrontendData(governorType, blocks, proposal, checks, markdownReport, destinationSimulations);
+  // Write simulation results JSON for both SIM_NAME and bulk modes
+  const simulationResultsPath = process.env.SIM_NAME
+    ? join(dirname(__dirname), 'frontend', 'public', 'simulation-results.json') // SIM_NAME mode: frontend directory
+    : `${path}-simulation-results.json`; // Bulk mode: alongside other reports
+
+  writeSimulationResultsJson(
+    governorType,
+    blocks,
+    proposal,
+    checks,
+    markdownReport,
+    governorAddress,
+    simulationResultsPath,
+    destinationSimulations,
+    executor,
+  );
 }
 
 /**

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -168,6 +168,8 @@ function generateStructuredReport(
   checks: AllCheckResults,
   governorAddress: string,
   executor?: string,
+  proposalCreatedBlock?: SimulationBlock,
+  proposalExecutedBlock?: SimulationBlock,
 ): StructuredSimulationReport {
   // Extract title and proposal text
   const title = getProposalTitle(proposal.description.trim());
@@ -332,12 +334,16 @@ function generateStructuredReport(
     events,
     calldata,
     metadata: {
-      blockNumber: blocks.current.number?.toString() ?? 'unknown',
-      timestamp: blocks.current.timestamp.toString(),
       proposalId: formatProposalId(governorType, proposal.id!),
       proposer: proposal.proposer,
       governorAddress,
       executor,
+      simulationBlockNumber: blocks.current.number?.toString() ?? 'unknown',
+      simulationTimestamp: blocks.current.timestamp.toString(),
+      proposalCreatedAtBlockNumber: proposalCreatedBlock?.number?.toString() ?? 'unknown',
+      proposalCreatedAtTimestamp: proposalCreatedBlock?.timestamp?.toString() ?? 'unknown',
+      proposalExecutedAtBlockNumber: proposalExecutedBlock?.number?.toString(),
+      proposalExecutedAtTimestamp: proposalExecutedBlock?.timestamp?.toString(),
     },
   };
 }
@@ -364,6 +370,8 @@ export function writeSimulationResultsJson(
   outputPath: string,
   destinationSimulations?: SimulationResult['destinationSimulations'],
   executor?: string,
+  proposalCreatedBlock?: SimulationBlock,
+  proposalExecutedBlock?: SimulationBlock,
 ) {
   try {
     // Extract the proposal data in the format expected by the frontend
@@ -385,6 +393,8 @@ export function writeSimulationResultsJson(
       checks,
       governorAddress,
       executor,
+      proposalCreatedBlock,
+      proposalExecutedBlock,
     );
 
     // Create a simplified report structure for the frontend
@@ -439,6 +449,8 @@ export async function generateAndSaveReports(
   destinationSimulations?: SimulationResult['destinationSimulations'],
   destinationChecks?: Record<number, AllCheckResults>,
   executor?: string,
+  proposalCreatedBlock?: SimulationBlock,
+  proposalExecutedBlock?: SimulationBlock,
 ) {
   console.log(`[Report] Generating report for proposal ${proposal.id} (${proposal.proposalId})`);
   console.log(`[Report] Output directory: ${outputDir}`);
@@ -482,6 +494,8 @@ export async function generateAndSaveReports(
     checks,
     governorAddress,
     executor,
+    proposalCreatedBlock,
+    proposalExecutedBlock,
   );
 
   // Save off all reports. The Markdown and PDF reports use the `markdownReport`.
@@ -519,6 +533,8 @@ export async function generateAndSaveReports(
     simulationResultsPath,
     destinationSimulations,
     executor,
+    proposalCreatedBlock,
+    proposalExecutedBlock,
   );
 }
 

--- a/run-checks.ts
+++ b/run-checks.ts
@@ -236,8 +236,10 @@ async function main() {
     finalResult.proposal,
     sourceChecks,
     dir,
+    config.governorAddress,
     finalResult.destinationSimulations,
     destinationChecks,
+    finalResult.executor,
   );
 }
 

--- a/run-checks.ts
+++ b/run-checks.ts
@@ -240,6 +240,8 @@ async function main() {
     finalResult.destinationSimulations,
     destinationChecks,
     finalResult.executor,
+    finalResult.proposalCreatedBlock,
+    finalResult.proposalExecutedBlock,
   );
 }
 

--- a/tests/simulation-results-metadata.test.ts
+++ b/tests/simulation-results-metadata.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  AllCheckResults,
+  GovernorType,
+  ProposalEvent,
+  SimulationBlock,
+  StructuredSimulationReport,
+} from '../types';
+
+// Import the actual functions we want to test
+import { generateAndSaveReports } from '../presentation/report';
+
+// Mock data for testing
+const mockProposal: ProposalEvent = {
+  id: 123n,
+  proposalId: 123n,
+  proposer: '0x1234567890abcdef1234567890abcdef12345678',
+  startBlock: 18000000n,
+  endBlock: 18100000n,
+  description: '# Test Proposal\n\nThis is a test proposal description.',
+  targets: ['0xabcdef1234567890abcdef1234567890abcdef12'],
+  values: [0n],
+  signatures: ['transfer(address,uint256)'],
+  calldatas: ['0x123456'],
+};
+
+const mockBlocks = {
+  current: { number: 18200000n, timestamp: 1700000000n } as SimulationBlock,
+  start: { number: 18000000n, timestamp: 1699000000n } as SimulationBlock,
+  end: { number: 18100000n, timestamp: 1699500000n } as SimulationBlock,
+};
+
+const mockGovernorAddress = '0x9876543210fedcba9876543210fedcba98765432' as const;
+
+const mockChecks: AllCheckResults = {
+  'test-check': {
+    name: 'Test Check',
+    result: {
+      errors: [],
+      warnings: ['Test warning'],
+      info: ['Test info'],
+    },
+  },
+};
+
+describe('Simulation Results Metadata', () => {
+  const testOutputDir = join(__dirname, 'test-output');
+
+  beforeEach(() => {
+    // Clean up any existing test files
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true });
+    }
+    mkdirSync(testOutputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up test files
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true });
+    }
+  });
+
+  test('should generate structured report with governorAddress in metadata', async () => {
+    // Generate reports in test directory
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      mockProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+    );
+
+    // Read the generated JSON file
+    const jsonPath = join(testOutputDir, '123.json');
+    expect(existsSync(jsonPath)).toBe(true);
+
+    const content = readFileSync(jsonPath, 'utf8');
+    const report: StructuredSimulationReport = JSON.parse(content);
+
+    // Test that metadata includes the new fields
+    expect(report.metadata.proposer).toBe(mockProposal.proposer);
+    expect(report.metadata.proposalId).toBe('123');
+
+    // These should fail until we implement the changes
+    expect(report.metadata.governorAddress).toBe(mockGovernorAddress);
+  });
+
+  test('should include executor field for executed proposals when different from proposer', async () => {
+    // Create a mock executed proposal where executor != proposer
+    const executorAddress = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const executedProposal = {
+      ...mockProposal,
+      proposer: '0x1234567890abcdef1234567890abcdef12345678', // Original proposer
+    };
+
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      executedProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+      undefined,
+      undefined,
+      executorAddress, // Pass the executor
+    );
+
+    const jsonPath = join(testOutputDir, '123.json');
+    const content = readFileSync(jsonPath, 'utf8');
+    const report: StructuredSimulationReport = JSON.parse(content);
+
+    // Should have the original proposer, not the executor
+    expect(report.metadata.proposer).toBe('0x1234567890abcdef1234567890abcdef12345678');
+
+    // This should fail until we implement executor tracking
+    expect(report.metadata.executor).toBe(executorAddress);
+  });
+
+  test('should include executor field even when proposer == executor', async () => {
+    // Test case where proposer == executor (executed by original proposer)
+    const proposerExecutorAddress = '0x1234567890abcdef1234567890abcdef12345678';
+    const executedProposal = {
+      ...mockProposal,
+      proposer: proposerExecutorAddress,
+    };
+
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      executedProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+      undefined,
+      undefined,
+      proposerExecutorAddress, // Pass the same address as executor
+    );
+
+    const jsonPath = join(testOutputDir, '123.json');
+    const content = readFileSync(jsonPath, 'utf8');
+    const report: StructuredSimulationReport = JSON.parse(content);
+
+    // executor field should be defined even when same as proposer
+    expect(report.metadata.proposer).toBe(proposerExecutorAddress);
+    expect(report.metadata.executor).toBe(proposerExecutorAddress);
+  });
+
+  test('should not include executor field for non-executed proposals', async () => {
+    // Test case for proposals that haven't been executed yet
+    const proposedOnlyProposal = {
+      ...mockProposal,
+      proposer: '0x1234567890abcdef1234567890abcdef12345678',
+    };
+
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      proposedOnlyProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+    );
+
+    const jsonPath = join(testOutputDir, '123.json');
+    const content = readFileSync(jsonPath, 'utf8');
+    const report: StructuredSimulationReport = JSON.parse(content);
+
+    // executor field should be undefined for non-executed proposals
+    expect(report.metadata.proposer).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(report.metadata.executor).toBeUndefined();
+  });
+
+  test('should generate simulation-results.json file in bulk mode', async () => {
+    // Test that we generate the frontend JSON file alongside the regular reports
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      mockProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+    );
+
+    // Check that the simulation-results.json file is created
+    const simulationResultsPath = join(testOutputDir, '123-simulation-results.json');
+
+    // This should fail until we implement the new writeSimulationResultsJson function
+    expect(existsSync(simulationResultsPath)).toBe(true);
+
+    if (existsSync(simulationResultsPath)) {
+      const content = readFileSync(simulationResultsPath, 'utf8');
+      const data = JSON.parse(content);
+
+      // Should be in the same format as the current frontend data
+      expect(data).toHaveProperty('proposalData');
+      expect(data).toHaveProperty('report');
+      expect(data.report.structuredReport.metadata.governorAddress).toBe(mockGovernorAddress);
+    }
+  });
+
+  test('should preserve proposer from ProposalCreated event, not tx.from', () => {
+    // This test validates that we extract the correct proposer from ProposalCreated events
+    // rather than using tx.from (which would be the executor for executed proposals)
+
+    // We'll need to mock the tenderly client behavior to test this properly
+    // For now, this serves as documentation of the bug we're fixing
+
+    const originalProposer = '0x1111111111111111111111111111111111111111';
+    const executor = '0x2222222222222222222222222222222222222222';
+
+    // When we fix the bug, the proposer should always be from ProposalCreated event
+    expect(originalProposer).not.toBe(executor);
+  });
+});
+
+describe('File Generation Tests', () => {
+  const testOutputDir = join(__dirname, 'test-output');
+
+  beforeEach(() => {
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true });
+    }
+    mkdirSync(testOutputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true });
+    }
+  });
+
+  test('should generate all expected report files', async () => {
+    await generateAndSaveReports(
+      'bravo' as GovernorType,
+      mockBlocks,
+      mockProposal,
+      mockChecks,
+      testOutputDir,
+      mockGovernorAddress,
+    );
+
+    // Check that all the standard files are generated
+    expect(existsSync(join(testOutputDir, '123.md'))).toBe(true);
+    expect(existsSync(join(testOutputDir, '123.html'))).toBe(true);
+    expect(existsSync(join(testOutputDir, '123.json'))).toBe(true);
+    expect(existsSync(join(testOutputDir, '123.pdf'))).toBe(true);
+
+    // Check that our new simulation-results file is also generated
+    expect(existsSync(join(testOutputDir, '123-simulation-results.json'))).toBe(true);
+  });
+});

--- a/tests/type-validation.test.ts
+++ b/tests/type-validation.test.ts
@@ -13,18 +13,20 @@ describe('Type Validation for Metadata Updates', () => {
       stateChanges: [],
       events: [],
       metadata: {
-        blockNumber: '18200000',
-        timestamp: '1700000000',
         proposalId: '123',
         proposer: '0x1234567890abcdef1234567890abcdef12345678',
-        governorAddress: '0x9876543210fedcba9876543210fedcba98765432', // This should be valid
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        simulationBlockNumber: '18200000',
+        simulationTimestamp: '1700000000',
+        proposalCreatedAtBlockNumber: '17800000',
+        proposalCreatedAtTimestamp: '1695000000',
       },
     };
 
     // These should pass once types are updated
     expect(mockReport.metadata.governorAddress).toBe('0x9876543210fedcba9876543210fedcba98765432');
     expect(mockReport.metadata.proposer).toBe('0x1234567890abcdef1234567890abcdef12345678');
-    expect(mockReport.metadata.blockNumber).toBe('18200000');
+    expect(mockReport.metadata.simulationBlockNumber).toBe('18200000');
   });
 
   test('StructuredSimulationReport metadata should optionally include executor', () => {
@@ -38,12 +40,16 @@ describe('Type Validation for Metadata Updates', () => {
       stateChanges: [],
       events: [],
       metadata: {
-        blockNumber: '18200000',
-        timestamp: '1700000000',
         proposalId: '123',
         proposer: '0x1234567890abcdef1234567890abcdef12345678',
         governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
-        executor: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', // This should be valid
+        executor: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        simulationBlockNumber: '18200000',
+        simulationTimestamp: '1700000000',
+        proposalCreatedAtBlockNumber: '17800000',
+        proposalCreatedAtTimestamp: '1695000000',
+        proposalExecutedAtBlockNumber: '17850000',
+        proposalExecutedAtTimestamp: '1696000000',
       },
     };
 
@@ -64,12 +70,14 @@ describe('Type Validation for Metadata Updates', () => {
       stateChanges: [],
       events: [],
       metadata: {
-        blockNumber: '18200000',
-        timestamp: '1700000000',
         proposalId: '123',
         proposer: '0x1234567890abcdef1234567890abcdef12345678',
         governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
-        // executor is optional for non-executed proposals
+        simulationBlockNumber: '18200000',
+        simulationTimestamp: '1700000000',
+        proposalCreatedAtBlockNumber: '17800000',
+        proposalCreatedAtTimestamp: '1695000000',
+        // executor and execution timing are optional for non-executed proposals
       },
     };
 
@@ -82,19 +90,23 @@ describe('Type Validation for Metadata Updates', () => {
   test('should validate required vs optional metadata fields', () => {
     // Test that all required fields are present
     const validMetadata = {
-      blockNumber: '18200000',
-      timestamp: '1700000000',
       proposalId: '123',
       proposer: '0x1234567890abcdef1234567890abcdef12345678',
       governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+      simulationBlockNumber: '18200000',
+      simulationTimestamp: '1700000000',
+      proposalCreatedAtBlockNumber: '17800000',
+      proposalCreatedAtTimestamp: '1695000000',
     };
 
     // All required fields should be strings or addresses
-    expect(typeof validMetadata.blockNumber).toBe('string');
-    expect(typeof validMetadata.timestamp).toBe('string');
     expect(typeof validMetadata.proposalId).toBe('string');
     expect(typeof validMetadata.proposer).toBe('string');
     expect(typeof validMetadata.governorAddress).toBe('string');
+    expect(typeof validMetadata.simulationBlockNumber).toBe('string');
+    expect(typeof validMetadata.simulationTimestamp).toBe('string');
+    expect(typeof validMetadata.proposalCreatedAtBlockNumber).toBe('string');
+    expect(typeof validMetadata.proposalCreatedAtTimestamp).toBe('string');
 
     // Validate address format (basic check)
     expect(validMetadata.proposer).toMatch(/^0x[a-fA-F0-9]{40}$/);

--- a/tests/type-validation.test.ts
+++ b/tests/type-validation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import type { StructuredSimulationReport } from '../types';
+
+describe('Type Validation for Metadata Updates', () => {
+  test('StructuredSimulationReport metadata should include governorAddress', () => {
+    // This test will fail until we update the type definition
+    const mockReport: StructuredSimulationReport = {
+      title: 'Test Proposal',
+      proposalText: 'Test proposal description',
+      status: 'success',
+      summary: 'Test summary',
+      checks: [],
+      stateChanges: [],
+      events: [],
+      metadata: {
+        blockNumber: '18200000',
+        timestamp: '1700000000',
+        proposalId: '123',
+        proposer: '0x1234567890abcdef1234567890abcdef12345678',
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432', // This should be valid
+      },
+    };
+
+    // These should pass once types are updated
+    expect(mockReport.metadata.governorAddress).toBe('0x9876543210fedcba9876543210fedcba98765432');
+    expect(mockReport.metadata.proposer).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(mockReport.metadata.blockNumber).toBe('18200000');
+  });
+
+  test('StructuredSimulationReport metadata should optionally include executor', () => {
+    // Test with executor field
+    const mockReportWithExecutor: StructuredSimulationReport = {
+      title: 'Test Proposal',
+      proposalText: 'Test proposal description',
+      status: 'success',
+      summary: 'Test summary',
+      checks: [],
+      stateChanges: [],
+      events: [],
+      metadata: {
+        blockNumber: '18200000',
+        timestamp: '1700000000',
+        proposalId: '123',
+        proposer: '0x1234567890abcdef1234567890abcdef12345678',
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        executor: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', // This should be valid
+      },
+    };
+
+    expect(mockReportWithExecutor.metadata.executor).toBe(
+      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    );
+    expect(mockReportWithExecutor.metadata.proposer).toBe(
+      '0x1234567890abcdef1234567890abcdef12345678',
+    );
+
+    // Test without executor field (should also be valid for non-executed proposals)
+    const mockReportWithoutExecutor: StructuredSimulationReport = {
+      title: 'Test Proposal',
+      proposalText: 'Test proposal description',
+      status: 'success',
+      summary: 'Test summary',
+      checks: [],
+      stateChanges: [],
+      events: [],
+      metadata: {
+        blockNumber: '18200000',
+        timestamp: '1700000000',
+        proposalId: '123',
+        proposer: '0x1234567890abcdef1234567890abcdef12345678',
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        // executor is optional for non-executed proposals
+      },
+    };
+
+    expect(mockReportWithoutExecutor.metadata.executor).toBeUndefined();
+    expect(mockReportWithoutExecutor.metadata.proposer).toBe(
+      '0x1234567890abcdef1234567890abcdef12345678',
+    );
+  });
+
+  test('should validate required vs optional metadata fields', () => {
+    // Test that all required fields are present
+    const validMetadata = {
+      blockNumber: '18200000',
+      timestamp: '1700000000',
+      proposalId: '123',
+      proposer: '0x1234567890abcdef1234567890abcdef12345678',
+      governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+    };
+
+    // All required fields should be strings or addresses
+    expect(typeof validMetadata.blockNumber).toBe('string');
+    expect(typeof validMetadata.timestamp).toBe('string');
+    expect(typeof validMetadata.proposalId).toBe('string');
+    expect(typeof validMetadata.proposer).toBe('string');
+    expect(typeof validMetadata.governorAddress).toBe('string');
+
+    // Validate address format (basic check)
+    expect(validMetadata.proposer).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(validMetadata.governorAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -75,6 +75,8 @@ export interface SimulationResult {
   deps: ProposalData;
   latestBlock: SimulationBlock;
   executor?: string; // Who executed the proposal (for executed proposals)
+  proposalCreatedBlock?: SimulationBlock; // Block when proposal was created
+  proposalExecutedBlock?: SimulationBlock; // Block when proposal was executed (for executed proposals)
   destinationSimulations?: Array<{
     chainId: number;
     bridgeType: string; // e.g., 'ArbitrumL1L2'
@@ -590,12 +592,16 @@ export interface StructuredSimulationReport {
   events: SimulationEvent[];
   calldata?: SimulationCalldata;
   metadata: {
-    blockNumber: string;
-    timestamp: string;
     proposalId: string;
     proposer: string;
     governorAddress: string;
     executor?: string;
+    simulationBlockNumber: string;
+    simulationTimestamp: string;
+    proposalCreatedAtBlockNumber: string;
+    proposalCreatedAtTimestamp: string;
+    proposalExecutedAtBlockNumber?: string;
+    proposalExecutedAtTimestamp?: string;
   };
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -74,6 +74,7 @@ export interface SimulationResult {
   proposal: ProposalEvent;
   deps: ProposalData;
   latestBlock: SimulationBlock;
+  executor?: string; // Who executed the proposal (for executed proposals)
   destinationSimulations?: Array<{
     chainId: number;
     bridgeType: string; // e.g., 'ArbitrumL1L2'
@@ -593,6 +594,8 @@ export interface StructuredSimulationReport {
     timestamp: string;
     proposalId: string;
     proposer: string;
+    governorAddress: string;
+    executor?: string;
   };
 }
 

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -650,7 +650,7 @@ async function simulateExecuted(config: SimulationConfigExecuted): Promise<Simul
     ...proposal,
     id: proposalId,
     proposalId: proposalId,
-    proposer: tx.from,
+    proposer: proposal.proposer ?? '', // Use original proposer from ProposalCreated event, not tx.from
     description: proposal.description ?? '',
     targets: [...(proposal.targets ?? [])],
     values: [...(proposal.values ?? [])],
@@ -668,7 +668,7 @@ async function simulateExecuted(config: SimulationConfigExecuted): Promise<Simul
     touchedContracts: sim.contracts.map((contract) => contract.address),
   };
 
-  return { sim, proposal: formattedProposal, latestBlock, deps };
+  return { sim, proposal: formattedProposal, latestBlock, deps, executor: tx.from };
 }
 
 /**

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -326,7 +326,10 @@ export async function simulateNew(config: SimulationConfigNew): Promise<Simulati
     touchedContracts: sim.contracts.map((contract) => contract.address),
   };
 
-  return { sim, proposal, latestBlock, deps };
+  // For new proposals, use simulation timing as created timing since they don't exist on-chain yet
+  const proposalCreatedBlock = latestBlock;
+
+  return { sim, proposal, latestBlock, deps, proposalCreatedBlock };
 }
 
 /**
@@ -572,7 +575,10 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
     touchedContracts: sim.contracts.map((contract) => contract.address),
   };
 
-  return { sim, proposal: formattedProposal, latestBlock, deps };
+  // Get block details for proposal creation timing
+  const proposalCreatedBlock = await publicClient.getBlock({ blockNumber: proposalCreatedEvent.blockNumber });
+
+  return { sim, proposal: formattedProposal, latestBlock, deps, proposalCreatedBlock };
 }
 
 /**
@@ -668,7 +674,21 @@ async function simulateExecuted(config: SimulationConfigExecuted): Promise<Simul
     touchedContracts: sim.contracts.map((contract) => contract.address),
   };
 
-  return { sim, proposal: formattedProposal, latestBlock, deps, executor: tx.from };
+  // Get block details for proposal creation and execution timing
+  const [proposalCreatedBlock, proposalExecutedBlock] = await Promise.all([
+    publicClient.getBlock({ blockNumber: proposalCreatedEvent.blockNumber }),
+    publicClient.getBlock({ blockNumber: proposalExecutedEvent.blockNumber }),
+  ]);
+
+  return { 
+    sim, 
+    proposal: formattedProposal, 
+    latestBlock, 
+    deps, 
+    executor: tx.from,
+    proposalCreatedBlock,
+    proposalExecutedBlock,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

• Replace ambiguous `blockNumber`/`timestamp` fields with explicit timing metadata
• Add clear separation between simulation context and actual proposal timeline  
• Enable GitHub app integration with proper multi-governor proposal tracking

## Changes

**Before (confusing):**
```json
{
  "blockNumber": "22726234", // When simulation was run (not helpful)
  "timestamp": "1750187615", // Simulation time (confusing)
  "proposalId": "42",
  "proposer": "0xa6e8772af29b29B9202a073f8E36f447689BEef6",
  "governorAddress": "0x408ED6354d4973f66138C91495F2f2FCbd8724C3"
}
```

**After (clear and useful):**
```json
{
  "proposalId": "42",
  "proposer": "0xa6e8772af29b29B9202a073f8E36f447689BEef6",
  "governorAddress": "0x408ED6354d4973f66138C91495F2f2FCbd8724C3",
  "executor": "0x63fad7cd939e6650a7f5d13462e8a350dcf09091",
  "simulationBlockNumber": "22726321",        // When we ran simulation
  "simulationTimestamp": "1750188671",
  "proposalCreatedAtBlockNumber": "17774312",  // When proposal was created
  "proposalCreatedAtTimestamp": "1690338935",
  "proposalExecutedAtBlockNumber": "17843378", // When proposal was executed
  "proposalExecutedAtTimestamp": "1691173403"
}
```

## Benefits

• **GitHub app integration**: Gets actual proposal creation/execution dates instead of simulation dates
• **Multi-governor support**: Clear `governorAddress` field enables differentiating between governors
• **Proper timeline**: Creation and execution timestamps reflect real on-chain events
• **Debugging capability**: Simulation timing preserved for troubleshooting

## Test Plan

- [x] Type check passes
- [x] Tested with Uniswap proposal 42 (executed proposal)
- [x] Verified metadata contains correct timing data:
  - Creation: July 26, 2023 (block 17774312)
  - Execution: August 4, 2023 (block 17843378) 
  - Simulation: Current time as expected
- [x] Updated tests validate new metadata structure
- [x] All entry points (`index.ts`, `run-checks.ts`) updated
- [x] Documentation updated with proposal running commands

🤖 Generated with [Claude Code](https://claude.ai/code)