### PR TITLE
fix: CI should use cached methodology instead of creating new cache every run

### DIFF
--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -35,16 +35,25 @@ jobs:
           path: |
             cache
             reports
-          key: ${{ runner.os }}-governance-cache-${{ github.run_number }}
+          key: ${{ runner.os }}-governance-cache-${{ hashFiles('package.json', 'bun.lockb', '**/*.ts', '**/*.js', 'checks/**/*', 'utils/**/*', 'presentation/**/*') }}
           restore-keys: |
             ${{ runner.os }}-governance-cache-
 
       - name: Install dependencies
         run: bun install
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-slither-v1
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Slither dependencies
         run: |
           pip3 install solc-select slither-analyzer
+          # Required solc versions for analyzing relevant Uniswap contracts
           solc-select install 0.8.19
           solc-select install 0.8.20
           solc-select use 0.8.20


### PR DESCRIPTION
## Summary

Fixes #40 - CI was taking 20 minutes instead of using cached proposal simulations because the cache key was creating a new cache entry every run.

## Changes Made

- **Fixed cache key**: Changed from `${{ github.run_number }}` to `${{ hashFiles('package.json', 'bun.lockb', '**/*.ts', '**/*.js', 'checks/**/*', 'utils/**/*', 'presentation/**/*') }}`
- **Added pip dependency caching**: Cache `~/.cache/pip` for faster Slither installation
- **Added documentation**: Comment explaining Solidity version requirements

## Expected Impact

- CI time reduction from ~20 minutes to ~2-5 minutes for most runs
- Cache will be reused when source code and dependencies haven't changed
- Cache will be properly invalidated when code or dependencies change

## Testing

- [x] Type check passes
- [x] Lint passes (existing warnings unrelated to changes)
- [x] Local simulation test passes with caching working correctly

The caching infrastructure was already implemented correctly in the codebase - this was purely a CI configuration issue.

🤖 Generated with [Claude Code](https://claude.ai/code)