### PR TITLE
docs: add support documentation for other DAOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,48 @@ bun test tests/check-eth-balance-changes.test.ts
 ```
 
 Currently, there is a test for the ETH balance changes check, which verifies that the check correctly identifies and reports ETH transfers and balance changes. As new checks are added or existing checks are modified, corresponding tests should be added to ensure their functionality. The test framework is set up to use Bun's built-in testing capabilities and can be extended to cover additional checks in the future.
+
+## Using Seatbelt for Other DAOs
+
+Seatbelt supports any Governor Bravo or OpenZeppelin Governor contract, making it suitable for governance safety analysis across the ecosystem.
+
+### Setup for Other DAOs
+
+To use Seatbelt with a different DAO:
+
+1. **Fork this repository** to your organization
+2. **Update environment variables** in your `.env` file:
+   ```bash
+   DAO_NAME=YourDAO
+   GOVERNOR_ADDRESS=0x... # Your governor contract address
+   ```
+3. **Test the setup** with a known proposal:
+   ```bash
+   bun start
+   ```
+
+### Supported Governor Types
+
+- **Governor Bravo**: Used by Compound, Uniswap, and many others
+- **OpenZeppelin Governor**: Modern governor standard
+
+The system automatically detects the governor type, so no manual configuration is needed.
+
+### Example Configurations
+
+**Compound:**
+```bash
+DAO_NAME=Compound
+GOVERNOR_ADDRESS=0xc0Da02939E1441F497fd74F78cE7Decb17B66529
+```
+
+**Custom DAO:**
+```bash
+DAO_NAME=YourDAO
+GOVERNOR_ADDRESS=0x... # Your governor address
+```
+
+For testing, you can also run specific simulations:
+```bash
+SIM_NAME=compound-43 bun start  # Test with existing Compound proposal
+```


### PR DESCRIPTION
## Summary
- Add comprehensive setup guide for using Seatbelt with other DAOs beyond Uniswap
- Include Compound as example configuration with tested governor address
- Document Governor Bravo and OpenZeppelin Governor support
- Provide clear testing instructions with existing compound-43 simulation
- Update CLAUDE.md to clarify fork vs upstream repository structure

## Test plan
- [x] Tested with Compound proposal 43 (executed) - generates complete reports
- [x] Tested with Compound proposal 390 (canceled) - handles state correctly  
- [x] Verified report generation in correct directory structure
- [x] Confirmed `bun run check-proposal` works with Compound governance

This enables other DAOs like Compound to easily adopt Seatbelt for governance safety analysis.

🤖 Generated with [Claude Code](https://claude.ai/code)