### PR TITLE
chore: document repo protections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS is used for review routing on sensitive paths.
+# We intentionally keep coverage scoped to "critical" files to avoid noisy review requests.
+
+# CI / automation
+/.github/workflows/ @marcomariscal
+
+# Dependency / toolchain surface
+/package.json @marcomariscal
+/bun.lockb @marcomariscal
+/bunfig.toml @marcomariscal
+/tsconfig.json @marcomariscal
+/biome.json @marcomariscal
+
+# Check execution surface (anything that runs or defines checks)
+/index.ts @marcomariscal
+/run-checks.ts @marcomariscal
+/run-proposal.sh @marcomariscal
+/checks/ @marcomariscal
+/utils/ @marcomariscal
+/sims/ @marcomariscal
+/presentation/ @marcomariscal
+/tests/ @marcomariscal

--- a/docs/repo-protections.md
+++ b/docs/repo-protections.md
@@ -1,0 +1,40 @@
+# Repo protections
+
+This repo is designed to be safe even when it is not actively maintained.
+
+## Goals
+
+- Keep `main` protected from accidental or malicious changes.
+- Avoid “fail-closed” rules that block merges when maintainers are unavailable.
+- Prefer automation gates (required CI checks) over required human reviews.
+
+## CODEOWNERS
+
+We use `.github/CODEOWNERS` to route review requests for critical paths (CI, dependency/toolchain files, and check execution code).
+
+Notes:
+- CODEOWNERS only *blocks merges* if branch protection enables “Require review from Code Owners”.
+- To avoid fail-closed behavior, we do **not** require code-owner reviews by default.
+
+## Recommended `main` branch protection (fail-open)
+
+Configure these in GitHub repo settings (they are not stored in git):
+
+- Require a pull request before merging: **ON**
+- Required approvals: **0**
+- Require review from Code Owners: **OFF**
+- Require status checks to pass before merging: **ON**
+  - Required checks:
+    - `Run Type Check`
+    - `Gitleaks Secret Scan`
+- Require conversation resolution before merging: **OFF**
+- Allow force pushes: **OFF**
+- Include administrators: **OFF** (admins can bypass in emergencies)
+
+## If you want stricter later
+
+If the repo becomes actively maintained again, consider:
+- Setting required approvals to **1+**
+- Enabling “Require review from Code Owners”
+- Adding required checks like `Run Tests` and `Check Uniswap Proposals` (and any future CodeQL checks)
+- Enabling “Require branches to be up to date before merging” (status checks “strict”)


### PR DESCRIPTION
## Summary
- Add CODEOWNERS review routing for critical paths
- Document fail-open branch protection settings for `main`

## Changes
- Added `.github/CODEOWNERS` scoped to CI/tooling/check execution surfaces
- Added `docs/repo-protections.md` with recommended `main` branch rules

## Test Plan
- `bun run check`

Resolves #88