### PR TITLE
feat: add cross-chain preview to structured reports

### DIFF
--- a/checks/check-decode-calldata.ts
+++ b/checks/check-decode-calldata.ts
@@ -153,9 +153,10 @@ function extractMeaningfulL2Calls(
     for (const call of calls || []) {
       // Skip system addresses and empty calls
       if (call.to && call.input && call.input !== '0x') {
-        // Skip Arbitrum system addresses
-        const isSystemAddress =
-          call.to.toLowerCase().includes('fffff') || call.to.toLowerCase().includes('00000');
+        // Skip common precompile/system address ranges (but keep OP Stack predeploys like 0x4200...)
+        const normalizedTo = call.to.toLowerCase();
+        const isLowPrecompileAddress = /^0x0{38}[0-9a-f]{2}$/.test(normalizedTo); // 0x...00xx
+        const isSystemAddress = normalizedTo.startsWith('0xfffff') || isLowPrecompileAddress;
 
         if (!isSystemAddress) {
           meaningfulCalls.push({

--- a/frontend/src/components/PermissionsDiff.tsx
+++ b/frontend/src/components/PermissionsDiff.tsx
@@ -12,15 +12,7 @@ type PermissionsDiffItem =
       via: 'event' | 'state_diff' | 'event+state_diff';
     }
   | {
-      kind: 'role_granted';
-      contractAddress: Address;
-      contractName?: string;
-      role: { id: `0x${string}`; name: string | null };
-      account: Address;
-      sender: Address;
-    }
-  | {
-      kind: 'role_revoked';
+      kind: 'role_granted' | 'role_revoked';
       contractAddress: Address;
       contractName?: string;
       role: { id: `0x${string}`; name: string | null };

--- a/frontend/src/components/StructuredReport.tsx
+++ b/frontend/src/components/StructuredReport.tsx
@@ -4,6 +4,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type {
+  CrossChainMessagePreview,
+  Proposal,
   SimulationCheck,
   SimulationStateChange,
   StructuredSimulationReport,
@@ -43,6 +45,10 @@ function buildAddressLink(
 ): string {
   const baseUrl = getExplorerUrl(metadata);
   return `${baseUrl}/address/${address}`;
+}
+
+function buildAddressLinkForExplorer(address: string, baseUrl: string): string {
+  return `${baseUrl || 'https://etherscan.io'}/address/${address}`;
 }
 
 export function buildBlockLink(
@@ -571,6 +577,7 @@ function ContractCard({ contract, variant }: ContractCardProps) {
 
 interface StructuredReportProps {
   report: StructuredSimulationReport;
+  proposal?: Proposal;
 }
 
 // Helper function for contextual executor labels
@@ -585,6 +592,276 @@ function getExecutorLabel(simulationType?: string): string {
     default:
       return 'Executor';
   }
+}
+
+function formatCrossChainCall(message: CrossChainMessagePreview): string {
+  if (message.call?.signature) return message.call.signature;
+  if (message.call?.selector) return message.call.selector;
+  if (message.l2InputData) return message.l2InputData.slice(0, 10);
+  return '(unknown)';
+}
+
+type CrossChainChainSummary = {
+  chainId: number;
+  chainName: string;
+  explorerBaseUrl: string;
+  bridgeType?: string;
+  total: number;
+  successCount: number;
+  failureCount: number;
+  failures: Array<{
+    index: number;
+    call: string;
+    targetLabel?: string;
+    target?: string;
+  }>;
+};
+
+function summarizeCrossChainMessages(messages: CrossChainMessagePreview[]): {
+  total: number;
+  successCount: number;
+  failureCount: number;
+  chains: CrossChainChainSummary[];
+} {
+  const byChain = new Map<number, CrossChainMessagePreview[]>();
+  for (const msg of messages) {
+    const list = byChain.get(msg.chainId) ?? [];
+    list.push(msg);
+    byChain.set(msg.chainId, list);
+  }
+
+  const chains: CrossChainChainSummary[] = Array.from(byChain.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([chainId, chainMessages]) => {
+      const chainName = chainMessages[0]?.chainName || `Chain ${chainId}`;
+      const explorerBaseUrl = chainMessages[0]?.blockExplorerBaseUrl || 'https://etherscan.io';
+      const bridgeType = chainMessages[0]?.bridgeType;
+      const successCount = chainMessages.filter((m) => m.status === 'success').length;
+      const failureCount = chainMessages.length - successCount;
+
+      return {
+        chainId,
+        chainName,
+        explorerBaseUrl,
+        bridgeType,
+        total: chainMessages.length,
+        successCount,
+        failureCount,
+        failures: chainMessages
+          .map((m, index) => ({
+            index,
+            call: formatCrossChainCall(m),
+            targetLabel: m.targetLabel,
+            target: m.l2TargetAddress,
+            status: m.status,
+          }))
+          .filter((m) => m.status === 'failure')
+          .map(({ index, call, targetLabel, target }) => ({ index, call, targetLabel, target })),
+      };
+    });
+
+  const total = chains.reduce((acc, c) => acc + c.total, 0);
+  const successCount = chains.reduce((acc, c) => acc + c.successCount, 0);
+  const failureCount = total - successCount;
+
+  return { total, successCount, failureCount, chains };
+}
+
+function CrossChainChecksSummary({ messages }: { messages: CrossChainMessagePreview[] }) {
+  const summary = useMemo(() => summarizeCrossChainMessages(messages), [messages]);
+  const hasFailures = summary.failureCount > 0;
+
+  return (
+    <div className="border border-muted rounded-md p-4 bg-card">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3">
+          {hasFailures ? (
+            <AlertTriangleIcon className="h-5 w-5 text-yellow-500 mt-0.5" />
+          ) : (
+            <CheckCircleIcon className="h-5 w-5 text-green-500 mt-0.5" />
+          )}
+          <div>
+            <div className="font-semibold">Cross-chain messages</div>
+            <div className="text-xs text-muted-foreground">
+              L2 message execution can fail independently of the main-chain checks.
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="bg-emerald-100 text-emerald-800 border-emerald-300">
+            {summary.successCount}/{summary.total} succeeded
+          </Badge>
+          {hasFailures ? (
+            <Badge variant="outline" className="bg-yellow-100 text-yellow-800 border-yellow-300">
+              {summary.failureCount} failed
+            </Badge>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {summary.chains.map((chain) => (
+          <div key={chain.chainId} className="border border-border/50 rounded-md p-3 bg-muted/20">
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <div className="text-sm font-medium">
+                {chain.chainName} ({chain.chainId})
+              </div>
+              <div className="flex items-center gap-2">
+                {chain.bridgeType ? (
+                  <Badge variant="outline" className="text-xs">
+                    {chain.bridgeType}
+                  </Badge>
+                ) : null}
+                <Badge variant="outline" className="text-xs bg-muted-foreground/10">
+                  {chain.successCount}/{chain.total} succeeded
+                </Badge>
+                {chain.failureCount > 0 ? (
+                  <Badge variant="destructive" className="text-xs">
+                    {chain.failureCount} failed
+                  </Badge>
+                ) : null}
+              </div>
+            </div>
+
+            {chain.failures.length ? (
+              <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                {chain.failures.map((m) => (
+                  <div
+                    key={`${chain.chainId}-${m.index}`}
+                    className="flex items-center gap-2 flex-wrap"
+                  >
+                    <span className="text-red-600 font-medium">Message {m.index + 1} failed:</span>
+                    <code className="font-mono bg-muted-foreground/10 px-1 py-0.5 rounded">
+                      {m.call}
+                    </code>
+                    {m.targetLabel ? <span>{m.targetLabel}</span> : null}
+                    {m.target ? (
+                      <a
+                        href={buildAddressLinkForExplorer(m.target, chain.explorerBaseUrl)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono bg-muted-foreground/10 px-1 py-0.5 rounded hover:underline inline-flex items-center"
+                        title={m.target}
+                      >
+                        {m.target.slice(0, 6)}...{m.target.slice(-4)}
+                        <ExternalLinkIcon className="h-3 w-3 ml-1" />
+                      </a>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CrossChainPreview({ messages }: { messages: CrossChainMessagePreview[] }) {
+  const groups = useMemo(() => {
+    const byChain = new Map<number, CrossChainMessagePreview[]>();
+    for (const msg of messages) {
+      const list = byChain.get(msg.chainId) ?? [];
+      list.push(msg);
+      byChain.set(msg.chainId, list);
+    }
+    return Array.from(byChain.entries()).sort(([a], [b]) => a - b);
+  }, [messages]);
+
+  return (
+    <div className="space-y-4">
+      {groups.map(([chainId, chainMessages]) => {
+        const chainName = chainMessages[0]?.chainName || `Chain ${chainId}`;
+        const explorerBaseUrl = chainMessages[0]?.blockExplorerBaseUrl || 'https://etherscan.io';
+        const bridgeType = chainMessages[0]?.bridgeType;
+
+        return (
+          <div key={chainId} className="border border-muted rounded-md p-4 bg-card">
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <div className="font-semibold">
+                {chainName} ({chainId})
+              </div>
+              {bridgeType ? (
+                <Badge variant="outline" className="text-xs">
+                  {bridgeType}
+                </Badge>
+              ) : null}
+            </div>
+
+            <div className="mt-3 space-y-3">
+              {chainMessages.map((message, index) => {
+                const messageKey = `${message.chainId}-${message.bridgeType}-${message.l2FromAddress ?? 'unknown'}-${message.l2TargetAddress ?? 'unknown'}-${message.l2InputData ?? 'unknown'}-${message.status}`;
+                const target = message.l2TargetAddress;
+                const targetLabel = message.targetLabel;
+                const call = formatCrossChainCall(message);
+
+                const statusBadge =
+                  message.status === 'success' ? (
+                    <Badge className="bg-emerald-100 text-emerald-800 border-emerald-300 text-xs">
+                      Succeeded
+                    </Badge>
+                  ) : (
+                    <Badge variant="destructive" className="text-xs">
+                      Failed
+                    </Badge>
+                  );
+
+                return (
+                  <div
+                    key={messageKey}
+                    className="border border-border/50 rounded-md bg-muted/30 p-3"
+                  >
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                      <div className="text-sm font-medium">Message {index + 1}</div>
+                      {statusBadge}
+                    </div>
+
+                    <div className="mt-2 space-y-1 text-sm">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-muted-foreground">Target:</span>
+                        {targetLabel ? <span>{targetLabel}</span> : null}
+                        {target ? (
+                          <a
+                            href={buildAddressLinkForExplorer(target, explorerBaseUrl)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-mono text-xs bg-muted-foreground/10 px-1 py-0.5 rounded hover:underline inline-flex items-center"
+                            title={target}
+                          >
+                            {target.slice(0, 6)}...{target.slice(-4)}
+                            <ExternalLinkIcon className="h-3 w-3 ml-1" />
+                          </a>
+                        ) : (
+                          <span className="text-muted-foreground">(unknown)</span>
+                        )}
+                      </div>
+
+                      <div className="flex items-start gap-2 flex-wrap">
+                        <span className="text-muted-foreground">Call:</span>
+                        <code className="font-mono text-xs bg-muted-foreground/10 px-1 py-0.5 rounded">
+                          {call}
+                        </code>
+                      </div>
+
+                      {message.error ? (
+                        <div className="text-xs text-red-700 mt-1">{message.error}</div>
+                      ) : message.status === 'failure' ? (
+                        <div className="text-xs text-muted-foreground mt-1">
+                          Failed (no error details captured)
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export function StructuredReport({ report }: StructuredReportProps) {
@@ -618,6 +895,13 @@ export function StructuredReport({ report }: StructuredReportProps) {
               value="overview"
               className="mt-4 space-y-6 absolute inset-0 overflow-y-auto pb-8 px-1"
             >
+              {report.crossChain?.messages?.length ? (
+                <div className="border border-muted rounded-md p-6 bg-card">
+                  <h3 className="text-lg font-semibold mb-3">Cross-Chain Preview</h3>
+                  <CrossChainPreview messages={report.crossChain.messages} />
+                </div>
+              ) : null}
+
               {report.proposalText && (
                 <div className="border border-muted rounded-md p-6 bg-card">
                   <h3 className="text-lg font-semibold mb-3">Proposal Details</h3>
@@ -723,6 +1007,9 @@ export function StructuredReport({ report }: StructuredReportProps) {
 
             <TabsContent value="checks" className="mt-4 absolute inset-0 overflow-y-auto pb-8 px-1">
               <div className="space-y-4">
+                {report.crossChain?.messages?.length ? (
+                  <CrossChainChecksSummary messages={report.crossChain.messages} />
+                ) : null}
                 {report.checks.length === 0 ? (
                   <div className="flex items-center justify-center p-6 text-muted-foreground border border-muted rounded-md">
                     <InfoIcon className="h-4 w-4 mr-2" />

--- a/frontend/src/hooks/use-simulation-results.ts
+++ b/frontend/src/hooks/use-simulation-results.ts
@@ -10,22 +10,25 @@ export interface Proposal {
   description: string;
 }
 
-export interface AddressLabel {
-  label: string;
-  type?: string;
-  source?: string;
-}
-
 export interface SimulationCheck {
   checkId?: string;
   title: string;
   status: 'passed' | 'warning' | 'failed' | 'skipped';
-  details?: string;
   skipReason?: string;
+  warningCount?: number;
+  errorCount?: number;
+  details?: string;
   info?: string[];
   warnings?: string[];
   errors?: string[];
   data?: unknown;
+  infoItems?: Array<{
+    label: string;
+    value: string;
+    isCode?: boolean;
+    isLink?: boolean;
+    href?: string;
+  }>;
 }
 
 export interface SimulationStateChange {
@@ -57,6 +60,71 @@ export interface SimulationCalldata {
   }>;
 }
 
+export interface AddressLabel {
+  label: string;
+  type?: 'governance' | 'token' | 'bridge' | 'contract' | 'user';
+  source?: 'custom' | 'ens' | 'tenderly';
+}
+
+export type PermissionsDiffItem =
+  | {
+      kind: 'ownership_transferred';
+      contractAddress: Address;
+      contractName?: string;
+      previous?: Address;
+      next: Address;
+      via: 'event' | 'state_diff' | 'event+state_diff';
+    }
+  | {
+      kind: 'role_granted' | 'role_revoked';
+      contractAddress: Address;
+      contractName?: string;
+      role: { id: `0x${string}`; name: string | null };
+      account: Address;
+      sender: Address;
+    }
+  | {
+      kind: 'timelock_admin_changed';
+      contractAddress: Address;
+      contractName?: string;
+      previous?: Address;
+      next: Address;
+      via: 'event' | 'state_diff' | 'event+state_diff';
+    }
+  | {
+      kind: 'timelock_pending_admin_changed';
+      contractAddress: Address;
+      contractName?: string;
+      previous?: Address;
+      next: Address;
+      via: 'event' | 'state_diff' | 'event+state_diff';
+    };
+
+export interface CrossChainDecodedCall {
+  selector: `0x${string}`;
+  signature?: string;
+  args?: unknown[];
+}
+
+export interface CrossChainMessagePreview {
+  chainId: number;
+  chainName: string;
+  blockExplorerBaseUrl: string;
+  bridgeType: string;
+  status: 'success' | 'failure';
+  error?: string;
+  l2FromAddress?: Address;
+  l2TargetAddress?: Address;
+  l2Value?: string;
+  l2InputData?: `0x${string}`;
+  targetLabel?: string;
+  call?: CrossChainDecodedCall;
+}
+
+export interface CrossChainPreview {
+  messages: CrossChainMessagePreview[];
+}
+
 export interface StructuredSimulationReport {
   title: string;
   proposalText: string;
@@ -65,7 +133,9 @@ export interface StructuredSimulationReport {
   checks: SimulationCheck[];
   stateChanges: SimulationStateChange[];
   events: SimulationEvent[];
+  permissionsDiff?: PermissionsDiffItem[];
   calldata?: SimulationCalldata;
+  crossChain?: CrossChainPreview;
   metadata: {
     // Legacy fields for backwards compatibility
     blockNumber?: string;
@@ -94,6 +164,7 @@ export interface StructuredSimulationReport {
     repoCommit?: string;
     repoUrl?: string;
     tenderlyUrl?: string;
+    // Address labels for entity identification (Issue #94)
     addressLabels?: Record<string, AddressLabel>;
   };
 }

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -13,7 +13,7 @@ import remarkToc from 'remark-toc';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 import type { Visitor } from 'unist-util-visit';
-import { getAddress } from 'viem';
+import { type Abi, getAddress, toFunctionSelector } from 'viem';
 import type {
   AllCheckResults,
   CoverageData,
@@ -32,6 +32,7 @@ import type {
   TenderlySimulation,
   WriteSimulationResultsJsonParams,
 } from '../types';
+import { BlockExplorerFactory } from '../utils/clients/block-explorers/factory';
 import { getChainConfig, publicClient } from '../utils/clients/client';
 import { DEFAULT_SIMULATION_ADDRESS, getContractName } from '../utils/clients/tenderly';
 import { formatProposalId } from '../utils/contracts/governor';
@@ -53,6 +54,175 @@ const CHAIN_NAMES: Record<number, string> = {
 
 function getChainName(chainId: number): string {
   return CHAIN_NAMES[chainId] || `Chain ${chainId}`;
+}
+
+// --- Cross-chain decoding helpers ---
+
+type AbiParameterLike = {
+  type: string;
+  components?: readonly AbiParameterLike[];
+};
+
+function formatAbiParameterType(param: {
+  type: string;
+  components?: readonly AbiParameterLike[];
+}): string {
+  const type = param.type;
+  if (!type.startsWith('tuple')) return type;
+
+  const arraySuffix = type.slice('tuple'.length); // "", "[]", "[2]", etc.
+  const components = param.components ?? [];
+  const inner = components.map((component) => formatAbiParameterType(component)).join(',');
+  return `(${inner})${arraySuffix}`;
+}
+
+function formatAbiFunctionSignature(fn: {
+  name: string;
+  inputs?: ReadonlyArray<{ type: string; components?: readonly AbiParameterLike[] }>;
+}): string {
+  const inputs = fn.inputs ?? [];
+  const formattedInputs = inputs.map((input) => formatAbiParameterType(input)).join(',');
+  return `${fn.name}(${formattedInputs})`;
+}
+
+const KNOWN_FUNCTION_SELECTORS: Record<string, string> = {
+  // ERC-20
+  '0xa9059cbb': 'transfer(address,uint256)',
+  '0x095ea7b3': 'approve(address,uint256)',
+  '0x23b872dd': 'transferFrom(address,address,uint256)',
+  // ERC20Votes / governance tokens
+  '0x5c19a95c': 'delegate(address)',
+  // WETH9-style
+  '0xd0e30db0': 'deposit()',
+  '0x2e1a7d4d': 'withdraw(uint256)',
+};
+
+const CONTRACT_ABI_CACHE = new Map<string, Abi | null>();
+const CONTRACT_ABI_PROMISE_CACHE = new Map<string, Promise<Abi | null>>();
+
+function getContractAbiCacheKey(target: string, chainId: number): string {
+  return `${chainId}:${target.toLowerCase()}`;
+}
+
+async function fetchContractAbiCached(target: string, chainId: number): Promise<Abi | null> {
+  const cacheKey = getContractAbiCacheKey(target, chainId);
+
+  if (CONTRACT_ABI_CACHE.has(cacheKey)) return CONTRACT_ABI_CACHE.get(cacheKey) ?? null;
+
+  const existingPromise = CONTRACT_ABI_PROMISE_CACHE.get(cacheKey);
+  if (existingPromise) return await existingPromise;
+
+  const promise = (async () => {
+    try {
+      return await BlockExplorerFactory.fetchContractAbi(target, chainId);
+    } catch {
+      return null;
+    }
+  })();
+
+  CONTRACT_ABI_PROMISE_CACHE.set(cacheKey, promise);
+
+  const abi = await promise;
+  CONTRACT_ABI_PROMISE_CACHE.delete(cacheKey);
+  CONTRACT_ABI_CACHE.set(cacheKey, abi);
+  return abi;
+}
+
+async function decodeContractCall(
+  target: string,
+  calldata: string,
+  chainId: number,
+): Promise<{ selector: string; signature?: string } | null> {
+  if (!calldata || calldata.length < 10) return null;
+
+  const selector = calldata.slice(0, 10).toLowerCase();
+  const knownSignature = KNOWN_FUNCTION_SELECTORS[selector];
+  if (knownSignature) return { selector, signature: knownSignature };
+
+  const abi = await fetchContractAbiCached(target, chainId);
+  if (!abi) return { selector };
+
+  let signature: string | undefined;
+  for (const item of abi) {
+    if (item.type !== 'function') continue;
+    try {
+      if (toFunctionSelector(item) === selector) {
+        signature = formatAbiFunctionSignature(item);
+        break;
+      }
+    } catch {
+      // Ignore malformed ABI entries.
+    }
+  }
+
+  return { selector, signature };
+}
+
+function getSimulationContractLabel(
+  simulation: TenderlySimulation | undefined,
+  address: string | undefined,
+): string | undefined {
+  if (!simulation || !address) return undefined;
+
+  try {
+    const match = simulation.contracts.find((c) => getAddress(c.address) === getAddress(address));
+
+    if (!match) return undefined;
+
+    if (match.token_data?.name && match.token_data?.symbol) {
+      return `${match.token_data.name} (${match.token_data.symbol})`;
+    }
+
+    if (match.contract_name) return match.contract_name;
+  } catch {
+    // Ignore bad addresses.
+  }
+
+  return undefined;
+}
+
+async function buildCrossChainPreview(
+  destinationSimulations: NonNullable<SimulationResult['destinationSimulations']>,
+): Promise<StructuredSimulationReport['crossChain']> {
+  const messages = await Promise.all(
+    destinationSimulations.map(async (dest) => {
+      const chainId = dest.chainId;
+
+      let blockExplorerBaseUrl = 'https://etherscan.io';
+      try {
+        blockExplorerBaseUrl = getChainConfig(chainId).blockExplorer.baseUrl;
+      } catch {
+        // Ignore unknown chain configs.
+      }
+
+      const l2TargetAddress = dest.l2Params?.l2TargetAddress;
+      const l2InputData = dest.l2Params?.l2InputData;
+
+      const call =
+        l2TargetAddress && l2InputData
+          ? await decodeContractCall(l2TargetAddress, l2InputData, chainId)
+          : undefined;
+
+      return {
+        chainId,
+        chainName: getChainName(chainId),
+        blockExplorerBaseUrl,
+        bridgeType: dest.bridgeType,
+        status: dest.status,
+        error: dest.error,
+        l2FromAddress: dest.l2Params?.l2FromAddress,
+        l2TargetAddress,
+        l2Value: dest.l2Params?.l2Value,
+        l2InputData,
+        targetLabel: getSimulationContractLabel(dest.sim, l2TargetAddress),
+        call: call
+          ? { selector: call.selector as `0x${string}`, signature: call.signature }
+          : undefined,
+      };
+    }),
+  );
+
+  return { messages };
 }
 
 // --- Repository and Tenderly utilities ---
@@ -879,6 +1049,16 @@ export async function generateAndSaveReports(params: GenerateReportsParams) {
     }
   }
 
+  // Add cross-chain preview data (Issue #101)
+  if (destinationSimulations && destinationSimulations.length > 0) {
+    try {
+      structuredReport.crossChain = await buildCrossChainPreview(destinationSimulations);
+    } catch (error) {
+      console.warn('[Report] Failed to build cross-chain preview:', error);
+      // Continue without cross-chain preview - it's optional.
+    }
+  }
+
   // Save off all reports. The Markdown and PDF reports use the `markdownReport`.
   await Promise.all([
     fsp.writeFile(`${path}.html`, htmlReport),
@@ -1050,12 +1230,32 @@ async function formatCrossChainResults(
       const blockExplorerUrl = chainConfig.blockExplorer.baseUrl;
 
       // Format L1 message details with correct block explorer links
-      const l1Messages = sims
-        .map((sim, index) => {
-          const l2Target = sim.l2Params?.l2TargetAddress;
-          return `  - Message ${index + 1}: ${l2Target ? `Target: ${toAddressLink(l2Target, blockExplorerUrl)}` : 'No target address'}`;
-        })
-        .join('\n');
+      const l1Messages = (
+        await Promise.all(
+          sims.map(async (sim, index) => {
+            const l2Target = sim.l2Params?.l2TargetAddress;
+            const l2InputData = sim.l2Params?.l2InputData;
+
+            if (!l2Target) return `  - Message ${index + 1}: No target address`;
+
+            const statusIcon = sim.status === 'success' ? '✅' : '❌';
+            const label = getSimulationContractLabel(sim.sim, l2Target);
+            const targetText = label
+              ? `Target: ${label} ${toAddressLink(l2Target, blockExplorerUrl)}`
+              : `Target: ${toAddressLink(l2Target, blockExplorerUrl)}`;
+
+            let callText = 'Call: (unknown)';
+            if (l2InputData) {
+              const decoded = await decodeContractCall(l2Target, l2InputData, Number(chainId));
+              if (decoded) {
+                callText = `Call: \`${decoded.signature || decoded.selector}\``;
+              }
+            }
+
+            return `  - Message ${index + 1} ${statusIcon}: ${targetText} • ${callText}`;
+          }),
+        )
+      ).join('\n');
 
       // Get overall chain status
       const allSuccessful = sims.every((sim) => sim.status === 'success');

--- a/sims/cross-chain-grok.sim.ts
+++ b/sims/cross-chain-grok.sim.ts
@@ -1,0 +1,136 @@
+import { encodeAbiParameters, encodeFunctionData, parseUnits } from 'viem';
+import type { Address } from 'viem';
+import type { SimulationConfigNew } from '../types';
+import ArbTokenAbi from '../utils/abis/ArbTokenAbi.json' assert { type: 'json' };
+import ArbitrumDelayedInboxAbi from '../utils/abis/ArbitrumDelayedInboxAbi.json' assert {
+  type: 'json',
+};
+
+/**
+ * Cross-chain "grokkability" stress test.
+ *
+ * Goal: produce multiple cross-chain messages across OP Stack + Arbitrum with a mix of
+ * obvious call signatures and intentional failures, so Markdown + UI can be verified
+ * as "ultra grokkable" at first glance.
+ */
+
+// --- OP Stack (OP Mainnet) ---
+const L1_CROSS_DOMAIN_MESSENGER_OP: Address = '0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1';
+const L2_WETH_PREDEPLOY_OP: Address = '0x4200000000000000000000000000000000000006';
+
+const opDepositMessage = '0xd0e30db0' as const; // deposit()
+const opWithdrawMessage = encodeFunctionData({
+  abi: [
+    {
+      type: 'function',
+      name: 'withdraw',
+      stateMutability: 'nonpayable',
+      inputs: [{ name: 'wad', type: 'uint256' }],
+      outputs: [],
+    },
+  ],
+  functionName: 'withdraw',
+  args: [parseUnits('1', 18)],
+});
+
+const opCall1 = {
+  target: L1_CROSS_DOMAIN_MESSENGER_OP,
+  calldata: encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }, { type: 'uint32' }],
+    [L2_WETH_PREDEPLOY_OP, opDepositMessage, 1_000_000],
+  ),
+  value: 0n,
+  signature: 'sendMessage(address,bytes,uint32)',
+};
+
+const opCall2 = {
+  target: L1_CROSS_DOMAIN_MESSENGER_OP,
+  calldata: encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }, { type: 'uint32' }],
+    [L2_WETH_PREDEPLOY_OP, opWithdrawMessage, 1_000_000],
+  ),
+  value: 0n,
+  signature: 'sendMessage(address,bytes,uint32)',
+};
+
+// --- Arbitrum (L1→L2 via Delayed Inbox) ---
+const ARB_DELAYED_INBOX_L1: Address = '0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f';
+const ARB_TOKEN_L2: Address = '0x912CE59144191C1204E64559FE8253a0e49E6548';
+const ARB_TIMELOCK_ALIAS_L2: Address = '0x2BAD8182C09F50c8318d769245beA52C32Be46CD';
+
+const recipientA: Address = '0xFd2892eFf2615C9F29AF83Fb528fAf3fE41c1426';
+const recipientB: Address = '0x66cCbf509cD28c2fc0f40b4469D6b6AA1FC0FeD3';
+
+// Likely-successful (no balance required): delegate(recipientA)
+const arbDelegateBytes = encodeFunctionData({
+  abi: ArbTokenAbi,
+  functionName: 'delegate',
+  args: [recipientA],
+});
+
+// Intentional failure candidate: transferFrom(recipientA, recipientB, 1)
+// (requires allowance that should not exist in the default sim context)
+const arbTransferFromBytes = encodeFunctionData({
+  abi: ArbTokenAbi,
+  functionName: 'transferFrom',
+  args: [recipientA, recipientB, 1n],
+});
+
+function makeArbRetryableTicket(l2Calldata: `0x${string}`) {
+  return {
+    target: ARB_DELAYED_INBOX_L1,
+    calldata: encodeFunctionData({
+      abi: ArbitrumDelayedInboxAbi,
+      functionName: 'createRetryableTicket',
+      args: [
+        ARB_TOKEN_L2, // to
+        0n, // l2CallValue
+        180_800_000_000_000n, // maxSubmissionCost
+        ARB_TIMELOCK_ALIAS_L2, // excessFeeRefundAddress
+        ARB_TIMELOCK_ALIAS_L2, // callValueRefundAddress
+        200_000n, // gasLimit
+        1_000_000_000n, // maxFeePerGas
+        l2Calldata, // data
+      ],
+    }),
+    value: 380_800_000_000_000n, // L1 ETH for L2 gas
+    signature: '',
+  } as const;
+}
+
+const arbCall1 = makeArbRetryableTicket(arbDelegateBytes);
+const arbCall2 = makeArbRetryableTicket(arbTransferFromBytes);
+
+const calls = [opCall1, opCall2, arbCall1, arbCall2];
+
+export const config: SimulationConfigNew = {
+  type: 'new',
+  daoName: 'CrossChainGrokkability',
+  governorAddress: '0x408ED6354d4973f66138C91495F2f2FCbd8724C3',
+  governorType: 'bravo',
+  targets: calls.map((call) => call.target),
+  values: calls.map((call) => call.value),
+  signatures: calls.map((call) => call.signature as `0x${string}`),
+  calldatas: calls.map((call) => call.calldata),
+  description: `# Cross-Chain Grokkability Stress Test
+
+This proposal is intentionally designed to stress cross-chain reporting in both Markdown and the UI.
+
+## Intentional Failures (on purpose)
+
+This simulation deliberately includes failing L2 calls to verify that per-message ✅/❌ status rendering and error surfacing are clear:
+
+- OP Stack (Optimism): \`withdraw(uint256)\` is expected to fail in the destination simulation context.
+- Arbitrum One: \`transferFrom(address,address,uint256)\` is expected to fail due to missing allowance/balance in the destination simulation context.
+
+## Expected Preview
+
+### OP Mainnet (OP Stack)
+- WETH predeploy: deposit()
+- WETH predeploy: withdraw(uint256) (likely failure in the destination simulation)
+
+### Arbitrum One
+- ARB token: delegate(address)
+- ARB token: transferFrom(address,address,uint256) (likely failure in the destination simulation)
+`,
+};

--- a/tests/schema-validation.test.ts
+++ b/tests/schema-validation.test.ts
@@ -77,6 +77,8 @@ describe('Schema validation at API boundaries', () => {
     const originalFetch = globalThis.fetch;
     SourcifyClient.clearCache();
 
+    SourcifyClient.clearCache();
+
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ not: 'an array' }), {
         status: 200,

--- a/types.d.ts
+++ b/types.d.ts
@@ -165,7 +165,15 @@ export type PermissionsDiffItem =
       sender: Address;
     }
   | {
-      kind: 'timelock_admin_changed' | 'timelock_pending_admin_changed';
+      kind: 'timelock_admin_changed';
+      contractAddress: Address;
+      contractName?: string;
+      previous?: Address;
+      next: Address;
+      via: 'event' | 'state_diff' | 'event+state_diff';
+    }
+  | {
+      kind: 'timelock_pending_admin_changed';
       contractAddress: Address;
       contractName?: string;
       previous?: Address;
@@ -670,6 +678,31 @@ export interface AddressLabel {
   source?: 'custom' | 'ens' | 'tenderly';
 }
 
+export interface CrossChainDecodedCall {
+  selector: Hex;
+  signature?: string;
+  args?: unknown[];
+}
+
+export interface CrossChainMessagePreview {
+  chainId: number;
+  chainName: string;
+  blockExplorerBaseUrl: string;
+  bridgeType: string;
+  status: 'success' | 'failure';
+  error?: string;
+  l2FromAddress?: Address;
+  l2TargetAddress?: Address;
+  l2Value?: string;
+  l2InputData?: Hex;
+  targetLabel?: string;
+  call?: CrossChainDecodedCall;
+}
+
+export interface CrossChainPreview {
+  messages: CrossChainMessagePreview[];
+}
+
 export interface StructuredSimulationReport {
   title: string;
   proposalText: string;
@@ -681,6 +714,7 @@ export interface StructuredSimulationReport {
   permissionsDiff?: PermissionsDiffItem[];
   calldata?: SimulationCalldata;
   coverage?: CoverageData;
+  crossChain?: CrossChainPreview;
   metadata: {
     proposalId: string;
     proposer: string;


### PR DESCRIPTION
## Summary
- Add a cross-chain preview section to the structured report UI
- Decode destination L2 calls (ABI first, known selectors fallback)

## Changes
- Emit `structuredReport.crossChain.messages` (chain/target/status/call) for destination simulations
- Add ABI fetch caching + safer calldata handling for call decoding
- Improve system/precompile filtering when extracting meaningful L2 calls
- Make Sourcify response parsing tolerant of missing `chainIds`

## Test Plan
- `bun run lint`
- `bun test`
- `SIM_NAME=cross-chain-grok bun run sim`

Resolves #101