### PR TITLE
fix: use contract name fallback in checkSolc

### DIFF
--- a/checks/check-solc.ts
+++ b/checks/check-solc.ts
@@ -3,7 +3,7 @@ import util from 'node:util';
 import { getAddress } from 'viem';
 import { codeBlock } from '../presentation/report';
 import type { ProposalCheck } from '../types';
-import { getContractNameFromTenderly } from '../utils/clients/tenderly';
+import { getContractName } from '../utils/clients/tenderly';
 import { ETHERSCAN_API_KEY } from '../utils/constants';
 import { getImplementation } from '../utils/contracts/governor';
 import { SECURITY_TOOL_TIMEOUT_MS } from '../utils/security-constants';
@@ -80,7 +80,7 @@ export const checkSolc: ProposalCheck = {
       }
 
       // Append results to report info.
-      const contractName = getContractNameFromTenderly(contract);
+      const contractName = await getContractName(contract, deps.chainConfig.chainId);
       if (result.output.stderr === '') {
         info.push(`No compiler warnings for ${contractName}`);
       } else {

--- a/tests/check-solc-naming.test.ts
+++ b/tests/check-solc-naming.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+describe('checkSolc naming', () => {
+  test('uses async getContractName() helper (not Tenderly-only naming)', async () => {
+    const source = await Bun.file('checks/check-solc.ts').text();
+
+    expect(source).toMatch(
+      /import\s+\{[^}]*getContractName[^}]*\}\s+from\s+['"]\.\.\/utils\/clients\/tenderly['"]/,
+    );
+    expect(source).not.toMatch(/getContractNameFromTenderly/);
+    expect(source).toMatch(/await\s+getContractName\s*\(/);
+  });
+});


### PR DESCRIPTION
## Summary
- Makes checkSolc use the unified async contract naming helper (Tenderly + explorer fallback)
- Reduces "Unknown Contract" labels in compiler-warning output

## Changes
- Switches checks/check-solc.ts to call getContractName(contract, chainId)
- Adds a static test to prevent regressions

## Test Plan
- bun run check
- bun test

Refs #133

(Stacks on PR #132; base can be retargeted to main after #132 merges.)