### PR TITLE
fix: use explorer fallback names in checkSolc

### DIFF
--- a/checks/check-solc.ts
+++ b/checks/check-solc.ts
@@ -70,17 +70,16 @@ export const checkSolc: ProposalCheck = {
       const addr = getAddress(contract.address);
       if (addressesToSkip.has(addr)) continue;
 
+      const contractName = await getContractName(contract, deps.chainConfig.chainId);
+
       // Compile the contracts.
       const result = await runCryticCompile(contract.address);
       if (!result.success) {
-        warnings.push(
-          `crytic-compile failed for \`${contract.contract_name}\` at \`${addr}\`: ${result.message}`,
-        );
+        warnings.push(`crytic-compile failed for ${contractName}: ${result.message}`);
         continue;
       }
 
       // Append results to report info.
-      const contractName = await getContractName(contract, deps.chainConfig.chainId);
       if (result.output.stderr === '') {
         info.push(`No compiler warnings for ${contractName}`);
       } else {

--- a/tests/check-solc-naming.test.ts
+++ b/tests/check-solc-naming.test.ts
@@ -8,6 +8,8 @@ describe('checkSolc naming', () => {
       /import\s+\{[^}]*getContractName[^}]*\}\s+from\s+['"]\.\.\/utils\/clients\/tenderly['"]/,
     );
     expect(source).not.toMatch(/getContractNameFromTenderly/);
+    // Ensure checkSolc doesn't label contracts using Tenderly-only `contract_name` fields.
+    expect(source).not.toMatch(/contract\.contract_name/);
     expect(source).toMatch(/await\s+getContractName\s*\(/);
   });
 });

--- a/tests/get-contract-name-fallback.test.ts
+++ b/tests/get-contract-name-fallback.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { getAddress } from 'viem';
+import type { TenderlyContract } from '../types.d';
+import { BlockExplorerFactory } from '../utils/clients/block-explorers/factory';
+import { getContractName } from '../utils/clients/tenderly';
+
+describe('getContractName() explorer fallback', () => {
+  test('uses explorer name when Tenderly name is missing (no network)', async () => {
+    const originalFetchContractName = BlockExplorerFactory.fetchContractName;
+    let called = false;
+    let seenAddress = '';
+    let seenChainId = 0;
+
+    BlockExplorerFactory.fetchContractName = async (address: string, chainId: number) => {
+      called = true;
+      seenAddress = address;
+      seenChainId = chainId;
+      return 'ExplorerFallbackName';
+    };
+
+    try {
+      const targetAddress = getAddress('0x0000000000000000000000000000000000000001');
+      const name = await getContractName({ address: targetAddress } as TenderlyContract, 1);
+
+      expect(called).toBe(true);
+      expect(seenAddress).toBe(targetAddress);
+      expect(seenChainId).toBe(1);
+      expect(name).toBe(`ExplorerFallbackName at \`${targetAddress}\``);
+    } finally {
+      BlockExplorerFactory.fetchContractName = originalFetchContractName;
+    }
+  });
+
+  test('does not change behavior when Tenderly already provides a name (no network)', async () => {
+    const originalFetchContractName = BlockExplorerFactory.fetchContractName;
+    BlockExplorerFactory.fetchContractName = async () => {
+      throw new Error('fetchContractName should not be called for Tenderly-named contracts');
+    };
+
+    try {
+      const address = getAddress('0x0000000000000000000000000000000000000002');
+      const name = await getContractName(
+        { address, contract_name: 'TenderlyName' } as TenderlyContract,
+        1,
+      );
+
+      expect(name).toBe(`TenderlyName at \`${address}\``);
+    } finally {
+      BlockExplorerFactory.fetchContractName = originalFetchContractName;
+    }
+  });
+});


### PR DESCRIPTION
- Use async contract naming (with explorer fallback) in checkSolc crytic-compile failure lines.
- Add unit tests for explorer name fallback (no network).

Resolves #133