### PR TITLE
chore: add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,17 @@
 
 # Always required.
 ETHERSCAN_API_KEY=yourEtherscanApiKey  # Single API key for all chains via Etherscan v2 API
-MAINNET_RPC_URL=yourMainnetRpcUrl  # Required for cross-chain functionality  
-ARBITRUM_RPC_URL=yourArbitrumRpcUrl  # Required for cross-chain functionality
+ALCHEMY_API_KEY=yourAlchemyApiKey  # Used as fallback/alternative RPC provider
+
+# Cross-chain RPC URLs (needed for proposals that touch L2s)
+MAINNET_RPC_URL=yourMainnetRpcUrl
+ARBITRUM_RPC_URL=yourArbitrumRpcUrl
+OPTIMISM_RPC_URL=yourOptimismRpcUrl
+BASE_RPC_URL=yourBaseRpcUrl
+UNICHAIN_RPC_URL=yourUnichainRpcUrl
+BOB_RPC_URL=yourBobRpcUrl
+INK_RPC_URL=yourInkRpcUrl
+SONEIUM_RPC_URL=yourSoneiumRpcUrl
 TENDERLY_ACCESS_TOKEN=yourTenderlyAccessToken
 TENDERLY_USER=yourTenderlyOrgOrMeIfPersonal
 TENDERLY_PROJECT_SLUG=yourTenderlyProjectSlug


### PR DESCRIPTION
Grepping `process.env.*` across the codebase revealed several RPC URL and API key variables that are used at runtime but were missing from `.env.example`.

**Added:**
- `OPTIMISM_RPC_URL`
- `BASE_RPC_URL`
- `UNICHAIN_RPC_URL`
- `BOB_RPC_URL`
- `INK_RPC_URL`
- `SONEIUM_RPC_URL`
- `ALCHEMY_API_KEY`

These are grouped under a "Cross-chain RPC URLs" comment alongside the existing `MAINNET_RPC_URL` and `ARBITRUM_RPC_URL`. `ALCHEMY_API_KEY` is placed near `ETHERSCAN_API_KEY` for discoverability.

No code changes — documentation only.