### PR TITLE
fix: add public RPC fallback for production builds

### DIFF
--- a/frontend/src/config/wagmi.ts
+++ b/frontend/src/config/wagmi.ts
@@ -13,8 +13,7 @@ const overrideChainId = process.env.NEXT_PUBLIC_CHAIN_ID
   : null;
 
 const mainnetRpcUrl =
-  process.env.NEXT_PUBLIC_MAINNET_RPC_URL ??
-  (isProduction ? undefined : 'https://eth.llamarpc.com');
+  process.env.NEXT_PUBLIC_MAINNET_RPC_URL ?? 'https://eth.llamarpc.com';
 
 const getChain = (): { chain: Chain; rpcUrl: string } => {
   if (overrideChainId && overrideChainId !== mainnet.id) {


### PR DESCRIPTION
The wagmi config threw `Mainnet RPC URL is not defined` during Vercel production builds because the llamarpc fallback was gated behind `!isProduction`. Published report viewers don't need a private RPC — the public endpoint is sufficient for optional wallet interactions.

**Before:** Every `bun upload --publish` deploy failed on Vercel build.
**After:** Builds succeed with public RPC fallback. Users can still override via `NEXT_PUBLIC_MAINNET_RPC_URL`.