### PR TITLE
fix: merge destination check results by chain

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import { generateAndSaveReports } from './presentation/report';
 import { buildCoverageFromResults, buildCoverageMetadata, runChecksForChain } from './run-checks';
 import type {
   AllCheckResults,
+  CheckResult,
   GovernorType,
   ProposalData,
   SimulationConfig,
@@ -48,6 +49,94 @@ const L2_CHECK_SUPPORTED_CHAIN_IDS = new Set([
 async function runSimulationPipeline(config: SimulationConfig): Promise<SimulationResult> {
   const sourceResult = await simulate(config);
   return await handleCrossChainSimulations(sourceResult);
+}
+
+function dedupeStrings(messages: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const message of messages) {
+    if (seen.has(message)) continue;
+    seen.add(message);
+    deduped.push(message);
+  }
+  return deduped;
+}
+
+function dedupeJsonValues<T>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+  for (const item of items) {
+    const key = JSON.stringify(item, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeCheckResult(current: CheckResult, next: CheckResult): CheckResult {
+  const info = dedupeStrings([...current.info, ...next.info]);
+  const warnings = dedupeStrings([...current.warnings, ...next.warnings]);
+  const errors = dedupeStrings([...current.errors, ...next.errors]);
+
+  // Treat merged checks as skipped only when all merged runs were skipped.
+  const skippedReasons = [current.skipped?.reason, next.skipped?.reason].filter(
+    (reason): reason is string => Boolean(reason),
+  );
+  const skipped =
+    current.skipped && next.skipped && skippedReasons.length > 0
+      ? { reason: dedupeStrings(skippedReasons).join(' | ') }
+      : undefined;
+
+  const permissionsDiffMerged = dedupeJsonValues([
+    ...(current.permissionsDiff ?? []),
+    ...(next.permissionsDiff ?? []),
+  ]);
+  const permissionsDiff = permissionsDiffMerged.length > 0 ? permissionsDiffMerged : undefined;
+
+  let data = current.data ?? next.data;
+  if (current.data !== undefined && next.data !== undefined) {
+    if (Array.isArray(current.data) && Array.isArray(next.data)) {
+      data = dedupeJsonValues([...current.data, ...next.data]);
+    } else if (isPlainObject(current.data) && isPlainObject(next.data)) {
+      data = { ...current.data, ...next.data };
+    }
+  }
+
+  return {
+    info,
+    warnings,
+    errors,
+    ...(data !== undefined ? { data } : {}),
+    ...(skipped ? { skipped } : {}),
+    ...(permissionsDiff ? { permissionsDiff } : {}),
+  };
+}
+
+function mergeAllCheckResults(current: AllCheckResults, next: AllCheckResults): AllCheckResults {
+  const merged: AllCheckResults = { ...current };
+
+  for (const [checkId, nextCheck] of Object.entries(next)) {
+    const currentCheck = merged[checkId];
+
+    if (!currentCheck) {
+      merged[checkId] = nextCheck;
+      continue;
+    }
+
+    merged[checkId] = {
+      name: currentCheck.name || nextCheck.name,
+      result: mergeCheckResult(currentCheck.result, nextCheck.result),
+    };
+  }
+
+  return merged;
 }
 
 /**
@@ -102,13 +191,16 @@ async function processDestinationSimulations(
           publicClient: getClientForChain(destSim.chainId),
           chainConfig: getChainConfig(destSim.chainId),
         };
-        destinationChecks[destSim.chainId] = await runChecksForChain(
+        const checkResults = await runChecksForChain(
           proposal,
           destSim.sim,
           l2Deps,
           destSim.chainId,
           destinationSimulations,
         );
+        destinationChecks[destSim.chainId] = destinationChecks[destSim.chainId]
+          ? mergeAllCheckResults(destinationChecks[destSim.chainId], checkResults)
+          : checkResults;
       } catch (error) {
         console.error(
           `[Index][L2_CHECK_FAILURE] Failed to run L2 checks for chain ${destSim.chainId}; continuing without destination checks for this chain.`,


### PR DESCRIPTION
## Summary
- Prevent destination check data from being overwritten when multiple cross-chain messages target the same destination chain.
- Ensure chain-level checks, state changes, and events include all successful destination message outcomes.

## Changes
- Added merge helpers to combine per-check results (dedupe info/warnings/errors, merge data, and dedupe permissions diffs).
- Updated destination simulation processing to merge destination check results by chain instead of replacing earlier runs.

## Test Plan
- bun run check:fix
- SIM_NAME=94 bun run sim
- SIM_NAME=95 bun run sim