### PR TITLE
fix: add 4byte fallback for cross-chain decode

### DIFF
--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types';
 import { BlockExplorerFactory } from '../utils/clients/block-explorers/factory';
 import { getChainConfig, publicClient } from '../utils/clients/client';
+import { lookupFunctionSignatureBySelector } from '../utils/clients/function-signature-registry';
 import { DEFAULT_SIMULATION_ADDRESS, getContractName } from '../utils/clients/tenderly';
 import { formatProposalId } from '../utils/contracts/governor';
 import { extractAddressesFromReport, resolveLabelsForAddresses } from '../utils/labels';
@@ -145,19 +146,24 @@ async function decodeContractCall(
   if (knownSignature) return { selector, signature: knownSignature };
 
   const abi = await fetchContractAbiCached(target, chainId);
-  if (!abi) return { selector };
-
   let signature: string | undefined;
-  for (const item of abi) {
-    if (item.type !== 'function') continue;
-    try {
-      if (toFunctionSelector(item) === selector) {
-        signature = formatAbiFunctionSignature(item);
-        break;
+  if (abi) {
+    for (const item of abi) {
+      if (item.type !== 'function') continue;
+      try {
+        if (toFunctionSelector(item) === selector) {
+          signature = formatAbiFunctionSignature(item);
+          break;
+        }
+      } catch {
+        // Ignore malformed ABI entries.
       }
-    } catch {
-      // Ignore malformed ABI entries.
     }
+  }
+
+  if (!signature) {
+    const fallbackSignature = await lookupFunctionSignatureBySelector(selector);
+    if (fallbackSignature) signature = fallbackSignature;
   }
 
   return { selector, signature };

--- a/tests/cross-chain-selector-fallback.test.ts
+++ b/tests/cross-chain-selector-fallback.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseAbi } from 'viem';
+import type {
+  AllCheckResults,
+  ProposalEvent,
+  SimulationBlock,
+  SimulationResult,
+  TenderlySimulation,
+} from '../types';
+import { clearFunctionSignatureRegistryCache } from '../utils/clients/function-signature-registry';
+
+describe('cross-chain selector fallback decode', () => {
+  function buildFixture(targetAddress = '0x00000000000000000000000000000000000000ab') {
+    const proposal: ProposalEvent = {
+      id: 181n,
+      proposalId: 181n,
+      proposer: '0x1234567890abcdef1234567890abcdef12345678',
+      startBlock: 19000000n,
+      endBlock: 19100000n,
+      description: '# Selector Fallback Regression Test',
+      targets: ['0xabcdef1234567890abcdef1234567890abcdef12'],
+      values: [0n],
+      signatures: [''],
+      calldatas: ['0x'],
+    };
+
+    const blocks = {
+      current: { number: 19200000n, timestamp: 1700000000n } as SimulationBlock,
+      start: { number: 19000000n, timestamp: 1699000000n } as SimulationBlock,
+      end: { number: 19100000n, timestamp: 1699500000n } as SimulationBlock,
+    };
+
+    const checks: AllCheckResults = {
+      'test-check': {
+        name: 'Test Check',
+        result: {
+          errors: [],
+          warnings: [],
+          info: ['ok'],
+        },
+      },
+    };
+
+    const l2TargetAddress = targetAddress;
+    const destinationSimulation: NonNullable<SimulationResult['destinationSimulations']>[number] = {
+      chainId: 196,
+      bridgeType: 'OptimismL1L2',
+      status: 'success' as const,
+      sim: {
+        contracts: [
+          {
+            address: l2TargetAddress,
+            contract_name: 'MockTarget',
+          },
+        ],
+        transaction: {
+          transaction_info: {
+            logs: [],
+          },
+        },
+      } as unknown as TenderlySimulation,
+      l2Params: {
+        bridgeType: 'OptimismL1L2' as const,
+        destinationChainId: '196',
+        l2TargetAddress: l2TargetAddress as `0x${string}`,
+        l2InputData:
+          '0x13af40350000000000000000000000001111111111111111111111111111111111111111' as `0x${string}`,
+        l2Value: '0',
+        l2FromAddress: '0x0000000000000000000000000000000000000001' as `0x${string}`,
+      },
+    };
+
+    return { proposal, blocks, checks, destinationSimulation };
+  }
+
+  it('uses 4byte fallback when explorer ABI lookup fails', async () => {
+    process.env.MAINNET_RPC_URL ??= 'http://localhost:8545';
+    process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
+    process.env.ETHERSCAN_API_KEY ??= 'test';
+    process.env.TENDERLY_ACCESS_TOKEN ??= 'test';
+    process.env.TENDERLY_USER ??= 'test';
+    process.env.TENDERLY_PROJECT_SLUG ??= 'test';
+
+    const { generateAndSaveReports } = await import('../presentation/report');
+    const { BlockExplorerFactory } = await import('../utils/clients/block-explorers/factory');
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-cross-chain-selector-'));
+    const originalFetch = globalThis.fetch;
+    const originalFetchContractAbi = BlockExplorerFactory.fetchContractAbi;
+
+    clearFunctionSignatureRegistryCache();
+
+    BlockExplorerFactory.fetchContractAbi = async () => null;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const urlString =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (!urlString.includes('4byte.directory')) {
+        throw new Error(`Unexpected fetch URL in test: ${urlString}`);
+      }
+
+      return new Response(
+        JSON.stringify({
+          count: 1,
+          results: [
+            {
+              text_signature: 'setOwner(address)',
+              hex_signature: '0x13af4035',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }) as typeof fetch;
+
+    const { proposal, blocks, checks, destinationSimulation } = buildFixture();
+
+    try {
+      await generateAndSaveReports({
+        governorType: 'bravo',
+        blocks,
+        proposal,
+        checks,
+        outputDir,
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        destinationSimulations: [destinationSimulation],
+      });
+
+      const structuredReportPath = join(outputDir, '181.json');
+      const markdownPath = join(outputDir, '181.md');
+
+      const structuredReport = JSON.parse(readFileSync(structuredReportPath, 'utf8')) as {
+        crossChain?: {
+          messages?: Array<{ call?: { signature?: string } }>;
+        };
+      };
+      const markdown = readFileSync(markdownPath, 'utf8');
+
+      const signature = structuredReport.crossChain?.messages?.[0]?.call?.signature;
+      expect(signature).toBe('setOwner(address)');
+      expect(markdown).toContain('Call: `setOwner(address)`');
+      expect(markdown).not.toContain('Call: `0x13af4035`');
+    } finally {
+      globalThis.fetch = originalFetch;
+      BlockExplorerFactory.fetchContractAbi = originalFetchContractAbi;
+      clearFunctionSignatureRegistryCache();
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it('prefers ABI decode over 4byte fallback when both are available', async () => {
+    process.env.MAINNET_RPC_URL ??= 'http://localhost:8545';
+    process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
+    process.env.ETHERSCAN_API_KEY ??= 'test';
+    process.env.TENDERLY_ACCESS_TOKEN ??= 'test';
+    process.env.TENDERLY_USER ??= 'test';
+    process.env.TENDERLY_PROJECT_SLUG ??= 'test';
+
+    const { generateAndSaveReports } = await import('../presentation/report');
+    const { BlockExplorerFactory } = await import('../utils/clients/block-explorers/factory');
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-cross-chain-abi-priority-'));
+    const originalFetch = globalThis.fetch;
+    const originalFetchContractAbi = BlockExplorerFactory.fetchContractAbi;
+    const { proposal, blocks, checks, destinationSimulation } = buildFixture(
+      '0x00000000000000000000000000000000000000ac',
+    );
+    let fourByteFetchCalls = 0;
+
+    clearFunctionSignatureRegistryCache();
+
+    const abi = parseAbi(['function setOwner(address _owner)']);
+    BlockExplorerFactory.fetchContractAbi = async () =>
+      abi as Awaited<ReturnType<typeof BlockExplorerFactory.fetchContractAbi>>;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const urlString =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (urlString.includes('4byte.directory')) fourByteFetchCalls += 1;
+      throw new Error(`Unexpected fetch URL in test: ${urlString}`);
+    }) as typeof fetch;
+
+    try {
+      await generateAndSaveReports({
+        governorType: 'bravo',
+        blocks,
+        proposal,
+        checks,
+        outputDir,
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        destinationSimulations: [destinationSimulation],
+      });
+
+      const structuredReportPath = join(outputDir, '181.json');
+      const markdownPath = join(outputDir, '181.md');
+
+      const structuredReport = JSON.parse(readFileSync(structuredReportPath, 'utf8')) as {
+        crossChain?: {
+          messages?: Array<{ call?: { signature?: string } }>;
+        };
+      };
+      const markdown = readFileSync(markdownPath, 'utf8');
+
+      expect(structuredReport.crossChain?.messages?.[0]?.call?.signature).toBe('setOwner(address)');
+      expect(markdown).toContain('Call: `setOwner(address)`');
+      expect(fourByteFetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      BlockExplorerFactory.fetchContractAbi = originalFetchContractAbi;
+      clearFunctionSignatureRegistryCache();
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/tests/function-signature-registry.test.ts
+++ b/tests/function-signature-registry.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  clearFunctionSignatureRegistryCache,
+  lookupFunctionSignatureBySelector,
+} from '../utils/clients/function-signature-registry';
+
+describe('function signature registry client (4byte)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    clearFunctionSignatureRegistryCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns decoded signature from a valid 4byte response', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          count: 1,
+          results: [
+            {
+              text_signature: 'setOwner(address)',
+              hex_signature: '0x13af4035',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )) as typeof fetch;
+
+    const signature = await lookupFunctionSignatureBySelector('0x13af4035');
+    expect(signature).toBe('setOwner(address)');
+  });
+
+  it('returns null for empty result sets', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          count: 0,
+          results: [],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )) as typeof fetch;
+
+    const signature = await lookupFunctionSignatureBySelector('0x13af4035');
+    expect(signature).toBeNull();
+  });
+
+  it('returns null on non-ok status and invalid payloads', async () => {
+    globalThis.fetch = (async () =>
+      new Response('error', {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    await expect(lookupFunctionSignatureBySelector('0x13af4035')).resolves.toBeNull();
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ not_results: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    await expect(lookupFunctionSignatureBySelector('0xa9059cbb')).resolves.toBeNull();
+  });
+
+  it('caches successful and null lookups', async () => {
+    let successFetchCount = 0;
+    globalThis.fetch = (async () => {
+      successFetchCount += 1;
+      return new Response(
+        JSON.stringify({
+          count: 1,
+          results: [{ text_signature: 'setOwner(address)', hex_signature: '0x13af4035' }],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }) as typeof fetch;
+
+    await expect(lookupFunctionSignatureBySelector('0x13af4035')).resolves.toBe(
+      'setOwner(address)',
+    );
+    await expect(lookupFunctionSignatureBySelector('0x13af4035')).resolves.toBe(
+      'setOwner(address)',
+    );
+    expect(successFetchCount).toBe(1);
+
+    clearFunctionSignatureRegistryCache();
+
+    let missFetchCount = 0;
+    globalThis.fetch = (async () => {
+      missFetchCount += 1;
+      return new Response(
+        JSON.stringify({
+          count: 0,
+          results: [],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }) as typeof fetch;
+
+    await expect(lookupFunctionSignatureBySelector('0xa9059cbb')).resolves.toBeNull();
+    await expect(lookupFunctionSignatureBySelector('0xa9059cbb')).resolves.toBeNull();
+    expect(missFetchCount).toBe(1);
+  });
+
+  it('deduplicates concurrent lookups for the same selector', async () => {
+    let fetchCount = 0;
+    let release: (() => void) | undefined;
+    const waitForRelease = new Promise<void>((resolve) => {
+      release = () => resolve();
+    });
+
+    globalThis.fetch = (async () => {
+      fetchCount += 1;
+      await waitForRelease;
+      return new Response(
+        JSON.stringify({
+          count: 1,
+          results: [{ text_signature: 'setOwner(address)', hex_signature: '0x13af4035' }],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }) as typeof fetch;
+
+    const first = lookupFunctionSignatureBySelector('0x13af4035');
+    const second = lookupFunctionSignatureBySelector('0x13af4035');
+    release?.();
+
+    await expect(first).resolves.toBe('setOwner(address)');
+    await expect(second).resolves.toBe('setOwner(address)');
+    expect(fetchCount).toBe(1);
+  });
+
+  it('selects deterministically when multiple valid signatures share a selector', async () => {
+    // Real collision pair discovered locally for selector 0x0dd521bb.
+    const selector = '0x0dd521bb';
+    const longCandidate = 'fnzvnqqzv(uint256,bytes32,bool)';
+    const shortCandidate = 'fwqdlhzfl(bool)';
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          count: 3,
+          results: [
+            { text_signature: longCandidate, hex_signature: selector },
+            { text_signature: 'transfer(address,uint256)', hex_signature: '0xa9059cbb' },
+            { text_signature: shortCandidate, hex_signature: selector },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )) as typeof fetch;
+
+    const first = await lookupFunctionSignatureBySelector(selector);
+    expect(first).toBe(shortCandidate);
+
+    clearFunctionSignatureRegistryCache();
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          count: 2,
+          results: [
+            { text_signature: shortCandidate, hex_signature: selector },
+            { text_signature: longCandidate, hex_signature: selector },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )) as typeof fetch;
+
+    const second = await lookupFunctionSignatureBySelector(selector);
+    expect(second).toBe(shortCandidate);
+  });
+});

--- a/utils/clients/function-signature-registry.ts
+++ b/utils/clients/function-signature-registry.ts
@@ -1,0 +1,94 @@
+import { toFunctionSelector } from 'viem';
+import { z } from '../validation/zod';
+
+const FOUR_BYTE_LOOKUP_TIMEOUT_MS = 2500;
+const FOUR_BYTE_ENDPOINT = 'https://www.4byte.directory/api/v1/signatures/';
+
+const selectorResultCache = new Map<string, string | null>();
+const selectorPromiseCache = new Map<string, Promise<string | null>>();
+
+const fourByteResponseSchema = z
+  .object({
+    results: z.array(
+      z
+        .object({
+          text_signature: z.string(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+function normalizeSelector(selector: string): string | null {
+  const normalized = selector.trim().toLowerCase();
+  return /^0x[0-9a-f]{8}$/.test(normalized) ? normalized : null;
+}
+
+function chooseBestSignature(selector: string, signatures: string[]): string | null {
+  const candidates = signatures
+    .map((signature) => signature.trim())
+    .filter((signature) => signature.length > 0)
+    .filter((signature) => {
+      try {
+        return toFunctionSelector(signature).toLowerCase() === selector;
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => a.length - b.length || a.localeCompare(b));
+
+  return candidates[0] ?? null;
+}
+
+async function fetchSignatureFrom4Byte(selector: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FOUR_BYTE_LOOKUP_TIMEOUT_MS);
+
+  try {
+    const url = `${FOUR_BYTE_ENDPOINT}?hex_signature=${selector}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+
+    const rawData = await response.json();
+    const parsed = fourByteResponseSchema.safeParse(rawData);
+    if (!parsed.success) return null;
+
+    const signatures = parsed.data.results.map((item) => item.text_signature);
+    return chooseBestSignature(selector, signatures);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function lookupFunctionSignatureBySelector(selector: string): Promise<string | null> {
+  const normalizedSelector = normalizeSelector(selector);
+  if (!normalizedSelector) return null;
+
+  if (selectorResultCache.has(normalizedSelector)) {
+    return selectorResultCache.get(normalizedSelector) ?? null;
+  }
+
+  const existingPromise = selectorPromiseCache.get(normalizedSelector);
+  if (existingPromise) return await existingPromise;
+
+  const lookupPromise = fetchSignatureFrom4Byte(normalizedSelector);
+  selectorPromiseCache.set(normalizedSelector, lookupPromise);
+
+  const signature = await lookupPromise;
+  selectorPromiseCache.delete(normalizedSelector);
+  selectorResultCache.set(normalizedSelector, signature);
+
+  return signature;
+}
+
+export function clearFunctionSignatureRegistryCache(): void {
+  selectorResultCache.clear();
+  selectorPromiseCache.clear();
+}


### PR DESCRIPTION
## Summary
- add a non-blocking selector-signature fallback using 4byte when ABI lookup fails
- keep decode precedence as known selectors -> ABI decode -> 4byte fallback -> raw selector
- preserve existing output shape while improving cross-chain call readability

## Changes
- add `utils/clients/function-signature-registry.ts` with timeout, schema validation, caching, and in-flight dedupe
- wire fallback lookup into `presentation/report.ts` `decodeContractCall()`
- add targeted unit tests for fallback client behavior and deterministic selector collision handling
- add regression tests for cross-chain fallback decode and ABI-over-fallback precedence

## Test Plan
- `bun run check`
- `bun test tests/function-signature-registry.test.ts`
- `bun test tests/cross-chain-selector-fallback.test.ts`
- ran `SIM_NAME=94 bun run sim` and `SIM_NAME=95 bun run sim` with env sourced, then verified decoded cross-chain signatures in outputs

Resolves #181
