### PR TITLE
fix: reduce share-link relay payload size

### DIFF
--- a/frontend/src/app/api/route-handlers.test.ts
+++ b/frontend/src/app/api/route-handlers.test.ts
@@ -126,6 +126,20 @@ function readFetchRequestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
+function readArtifactRawFromRelayRequest(init?: RequestInit): string | null {
+  if (!init || typeof init.body !== 'string') return null;
+
+  try {
+    const payload: unknown = JSON.parse(init.body);
+    if (!payload || typeof payload !== 'object') return null;
+
+    const artifactRaw = Reflect.get(payload, 'artifactRaw');
+    return typeof artifactRaw === 'string' ? artifactRaw : null;
+  } catch {
+    return null;
+  }
+}
+
 beforeEach(() => {
   restoreEnvironment();
   restoreSimulationResultsFile();
@@ -329,6 +343,46 @@ describe('/api/share-link', () => {
       'https://seatbelt-publish.vercel.app/simulation-results.json',
     );
     expect(readViewerUrl(payload)).toBe('https://seatbelt.app');
+  });
+
+  it('strips markdownReport before publishing artifact via relay', async () => {
+    writeSimulationResultsFile(VALID_SIMULATION_RESULTS_JSON);
+    process.env.SEATBELT_RELAY_URL = 'https://seatbelt-relay-beta.vercel.app';
+
+    let publishedArtifactRaw: string | null = null;
+    globalThis.fetch = createMockFetch(
+      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        publishedArtifactRaw = readArtifactRawFromRelayRequest(init);
+
+        return new Response(
+          JSON.stringify({
+            artifactUrl: 'https://seatbelt-publish.vercel.app/simulation-results.json',
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      },
+    );
+
+    const response = await postShareLink(
+      new Request('http://localhost/api/share-link', {
+        method: 'POST',
+        headers: {
+          'x-forwarded-for': '203.0.113.11',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(publishedArtifactRaw).not.toBeNull();
+    const publishedPayload = publishedArtifactRaw
+      ? (JSON.parse(publishedArtifactRaw) as unknown)
+      : null;
+    expect(readMarkdownReport(publishedPayload)).toBe('');
   });
 
   it('returns 429 when share-link endpoint exceeds rate limit', async () => {

--- a/frontend/src/app/api/share-link/route.ts
+++ b/frontend/src/app/api/share-link/route.ts
@@ -157,6 +157,19 @@ function readRawArtifact(
   }
 }
 
+function stripMarkdownReports(artifact: ReturnType<typeof parseSimulationResultsJson>): string {
+  // Keep payloads small enough for serverless relay limits.
+  const artifactWithoutMarkdown = artifact.map((result) => ({
+    ...result,
+    report: {
+      ...result.report,
+      markdownReport: '',
+    },
+  }));
+
+  return JSON.stringify(artifactWithoutMarkdown);
+}
+
 async function publishViaManagedRelay(
   artifactRaw: string,
   artifactHash: string,
@@ -250,10 +263,11 @@ export async function POST(request: Request) {
     }
 
     const parsedArtifact: unknown = JSON.parse(readResult.artifactRaw);
-    parseSimulationResultsJson(parsedArtifact);
+    const normalizedArtifact = parseSimulationResultsJson(parsedArtifact);
+    const artifactRawForPublish = stripMarkdownReports(normalizedArtifact);
 
-    const artifactHash = createHash('sha256').update(readResult.artifactRaw).digest('hex');
-    const publishResult = await publishViaManagedRelay(readResult.artifactRaw, artifactHash);
+    const artifactHash = createHash('sha256').update(artifactRawForPublish).digest('hex');
+    const publishResult = await publishViaManagedRelay(artifactRawForPublish, artifactHash);
 
     if ('error' in publishResult) {
       return NextResponse.json({ error: publishResult.error }, { status: publishResult.status });


### PR DESCRIPTION
## Summary
- Prevent share-link publish requests from exceeding serverless payload constraints
- Keep publish behavior unchanged while reducing request size for large simulations

## Changes
- Strip `report.markdownReport` from artifact JSON before sending `artifactRaw` to the relay
- Compute relay idempotency hash from the slimmed publish payload
- Add API route test coverage to assert relay-bound payload omits markdown content

## Test Plan
- `bun run check` (frontend)
- `bun test frontend/src/app/api/route-handlers.test.ts`
- Manual verification: production `POST /api/share-link` returns success for sim 95