### PR TITLE
fix: scope permission diff rendering by chain

### DIFF
--- a/frontend/src/components/StructuredReport.tsx
+++ b/frontend/src/components/StructuredReport.tsx
@@ -72,6 +72,7 @@ export function StructuredReport({ report, proposal }: StructuredReportProps) {
           checks: report.checks,
           stateChanges: report.stateChanges,
           events: report.events,
+          permissionsDiff: report.permissionsDiff,
         },
       ];
 
@@ -335,6 +336,8 @@ export function StructuredReport({ report, proposal }: StructuredReportProps) {
               blockExplorerBaseUrl:
                 chainReport.blockExplorerBaseUrl || report.metadata.blockExplorerBaseUrl,
             };
+            const chainPermissionsDiff =
+              chainReport.permissionsDiff ?? (isMainChain ? report.permissionsDiff : undefined);
 
             return (
               <section
@@ -392,7 +395,7 @@ export function StructuredReport({ report, proposal }: StructuredReportProps) {
                     stateChanges={chainReport.stateChanges}
                     metadata={effectiveMetadata}
                     coverageByCheckId={coverageByCheckId}
-                    permissionsDiff={report.permissionsDiff}
+                    permissionsDiff={chainPermissionsDiff}
                   />
                 )}
               </section>

--- a/frontend/src/hooks/use-simulation-results.ts
+++ b/frontend/src/hooks/use-simulation-results.ts
@@ -165,6 +165,7 @@ export interface ChainSimulationReport {
   checks: SimulationCheck[];
   stateChanges: SimulationStateChange[];
   events: SimulationEvent[];
+  permissionsDiff?: PermissionsDiffItem[];
 }
 
 export interface StructuredSimulationReport {

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -858,6 +858,7 @@ function generateStructuredReport(
 
   const mainStateChanges = extractStateChanges(checks);
   const mainEvents = extractEvents(checks);
+  const mainPermissionsDiff = extractPermissionsDiff(checks);
 
   const chainReports: StructuredSimulationReport['chainReports'] = [
     {
@@ -868,6 +869,7 @@ function generateStructuredReport(
       checks: formattedChecks,
       stateChanges: mainStateChanges,
       events: mainEvents,
+      permissionsDiff: mainPermissionsDiff,
     },
     ...Object.entries(destinationChecks ?? {}).map(([chainIdStr, destChecks]) => {
       const destChainId = Number(chainIdStr);
@@ -887,6 +889,7 @@ function generateStructuredReport(
         checks: formatChecksForStructuredReport(destChecks, destChainId),
         stateChanges: extractStateChanges(destChecks),
         events: extractEvents(destChecks),
+        permissionsDiff: extractPermissionsDiff(destChecks),
       };
     }),
   ];
@@ -900,7 +903,7 @@ function generateStructuredReport(
     stateChanges: mainStateChanges,
     events: mainEvents,
     chainReports,
-    permissionsDiff: extractPermissionsDiff(checks),
+    permissionsDiff: mainPermissionsDiff,
     calldata: extractCalldata(checks, proposal),
     metadata: {
       proposalId: formatProposalId(governorType, proposal.id!),

--- a/tests/chain-scoped-permissions-diff.test.ts
+++ b/tests/chain-scoped-permissions-diff.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  AllCheckResults,
+  PermissionsDiffItem,
+  ProposalEvent,
+  SimulationBlock,
+} from '../types';
+
+const governorAddress = '0x3333333333333333333333333333333333333333';
+
+function makeMockProposal(): ProposalEvent {
+  return {
+    id: 194n,
+    proposalId: 194n,
+    proposer: '0x1111111111111111111111111111111111111111',
+    startBlock: 999n,
+    endBlock: 1001n,
+    description: '# Cross-chain permissions regression',
+    targets: ['0x2222222222222222222222222222222222222222'],
+    values: [0n],
+    signatures: ['test()'],
+    calldatas: ['0x'],
+  };
+}
+
+function makeMockBlocks(): { current: SimulationBlock; start: null; end: null } {
+  return {
+    current: { number: 1000n, timestamp: 1234567890n },
+    start: null,
+    end: null,
+  };
+}
+
+describe('chain-scoped permissions diff in structured report', () => {
+  test('keeps main-chain permissions empty while preserving L2 permission warnings + diff items', async () => {
+    process.env.MAINNET_RPC_URL ??= 'http://localhost:8545';
+    process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
+    process.env.ETHERSCAN_API_KEY ??= 'test';
+    process.env.TENDERLY_ACCESS_TOKEN ??= 'test';
+    process.env.TENDERLY_USER ??= 'test';
+    process.env.TENDERLY_PROJECT_SLUG ??= 'test';
+
+    const { writeSimulationResultsJson } = await import('../presentation/report');
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-chain-permissions-'));
+    const outputPath = join(outputDir, 'simulation-results.json');
+
+    const mainChecks: AllCheckResults = {
+      checkPermissionDiff: {
+        name: 'Permission Changes',
+        result: {
+          errors: [],
+          warnings: [],
+          info: ['No permission changes'],
+          permissionsDiff: [],
+        },
+      },
+    };
+
+    const l2DiffItem: PermissionsDiffItem = {
+      kind: 'ownership_transferred',
+      contractAddress: '0x4444444444444444444444444444444444444444',
+      previous: '0x5555555555555555555555555555555555555555',
+      next: '0x6666666666666666666666666666666666666666',
+      via: 'event',
+    };
+
+    const destinationChecks: Record<number, AllCheckResults> = {
+      1868: {
+        checkPermissionDiff: {
+          name: 'Permission Changes',
+          result: {
+            errors: [],
+            warnings: ['Ownership transfer detected'],
+            info: [],
+            permissionsDiff: [l2DiffItem],
+          },
+        },
+      },
+    };
+
+    try {
+      writeSimulationResultsJson({
+        governorType: 'oz',
+        blocks: makeMockBlocks(),
+        proposal: makeMockProposal(),
+        checks: mainChecks,
+        markdownReport: '# Test Report',
+        governorAddress,
+        outputPath,
+        destinationChecks,
+      });
+
+      const parsed: {
+        report: {
+          structuredReport: {
+            permissionsDiff?: PermissionsDiffItem[];
+            chainReports?: Array<{
+              chainId: number;
+              checks: Array<{ checkId?: string; status?: string }>;
+              permissionsDiff?: PermissionsDiffItem[];
+            }>;
+          };
+        };
+      } = JSON.parse(readFileSync(outputPath, 'utf8'));
+
+      const structuredReport = parsed.report.structuredReport;
+      const chainReports = structuredReport.chainReports ?? [];
+      const mainChain = chainReports.find((report) => report.chainId === 1);
+      const l2Chain = chainReports.find((report) => report.chainId === 1868);
+
+      expect(structuredReport.permissionsDiff).toEqual([]);
+      expect(mainChain?.permissionsDiff).toEqual([]);
+      expect(l2Chain?.permissionsDiff).toEqual([l2DiffItem]);
+
+      const l2PermissionCheck = l2Chain?.checks.find(
+        (check) => check.checkId === 'checkPermissionDiff',
+      );
+      expect(l2PermissionCheck?.status).toBe('warning');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -769,6 +769,7 @@ export interface ChainSimulationReport {
   checks: SimulationCheck[];
   stateChanges: SimulationStateChange[];
   events: SimulationEvent[];
+  permissionsDiff?: PermissionsDiffItem[];
 }
 
 export interface GenerateReportsParams {


### PR DESCRIPTION
## Summary
- add per-chain permissions diff extraction in structured report generation (`chainReports[*].permissionsDiff`)
- keep top-level `structuredReport.permissionsDiff` as main-chain data for backward compatibility
- update frontend checks rendering to use each chain report's permission diff (with main-chain fallback for legacy artifacts)
- add regression test for cross-chain case where main-chain permission diff is empty but L2 has permission warnings

## Validation
- `bun run check`
- `bun test tests/chain-scoped-permissions-diff.test.ts checks/tests/report-json-contract.test.ts`
- `cd frontend && bun run check`

Fixes #194