### PR TITLE
fix: improve destination check resilience and diagnostics

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,10 +5,14 @@
 import { existsSync } from 'node:fs';
 import { getAddress } from 'viem';
 import { generateAndSaveReports } from './presentation/report';
-import { buildCoverageFromResults, buildCoverageMetadata, runChecksForChain } from './run-checks';
+import {
+  appendDestinationCoverageDiagnostics,
+  buildCoverageFromResults,
+  buildCoverageMetadata,
+  processDestinationChecks,
+  runChecksForChainWithDiagnostics,
+} from './run-checks';
 import type {
-  AllCheckResults,
-  CheckResult,
   GovernorType,
   ProposalData,
   SimulationConfig,
@@ -17,7 +21,7 @@ import type {
   SimulationResult,
 } from './types';
 import { cacheProposal, getCachedProposal, needsSimulation } from './utils/cache/proposalCache';
-import { getChainConfig, getClientForChain, publicClient } from './utils/clients/client';
+import { getChainConfig, publicClient } from './utils/clients/client';
 import { handleCrossChainSimulations, simulate } from './utils/clients/tenderly';
 import { DAO_NAME, GOVERNOR_ADDRESS, REPORTS_OUTPUT_DIRECTORY, SIM_NAME } from './utils/constants';
 import {
@@ -29,114 +33,12 @@ import {
 } from './utils/contracts/governor';
 import { PROPOSAL_STATES } from './utils/contracts/governor-bravo';
 
-const L2_CHECK_SUPPORTED_CHAIN_IDS = new Set([
-  10, // Optimism
-  8453, // Base
-  42161, // Arbitrum
-  130, // Unichain
-  57073, // Ink
-  1868, // Soneium
-  60808, // Bob
-  196, // X Layer
-  42220, // Celo
-  480, // World Chain
-  7777777, // Zora
-]);
-
 /**
  * @notice Run the complete simulation pipeline (source + cross-chain)
  */
 async function runSimulationPipeline(config: SimulationConfig): Promise<SimulationResult> {
   const sourceResult = await simulate(config);
   return await handleCrossChainSimulations(sourceResult);
-}
-
-function dedupeStrings(messages: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const message of messages) {
-    if (seen.has(message)) continue;
-    seen.add(message);
-    deduped.push(message);
-  }
-  return deduped;
-}
-
-function dedupeJsonValues<T>(items: T[]): T[] {
-  const seen = new Set<string>();
-  const deduped: T[] = [];
-  for (const item of items) {
-    const key = JSON.stringify(item, (_, value) =>
-      typeof value === 'bigint' ? value.toString() : value,
-    );
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(item);
-  }
-  return deduped;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function mergeCheckResult(current: CheckResult, next: CheckResult): CheckResult {
-  const info = dedupeStrings([...current.info, ...next.info]);
-  const warnings = dedupeStrings([...current.warnings, ...next.warnings]);
-  const errors = dedupeStrings([...current.errors, ...next.errors]);
-
-  // Treat merged checks as skipped only when all merged runs were skipped.
-  const skippedReasons = [current.skipped?.reason, next.skipped?.reason].filter(
-    (reason): reason is string => Boolean(reason),
-  );
-  const skipped =
-    current.skipped && next.skipped && skippedReasons.length > 0
-      ? { reason: dedupeStrings(skippedReasons).join(' | ') }
-      : undefined;
-
-  const permissionsDiffMerged = dedupeJsonValues([
-    ...(current.permissionsDiff ?? []),
-    ...(next.permissionsDiff ?? []),
-  ]);
-  const permissionsDiff = permissionsDiffMerged.length > 0 ? permissionsDiffMerged : undefined;
-
-  let data = current.data ?? next.data;
-  if (current.data !== undefined && next.data !== undefined) {
-    if (Array.isArray(current.data) && Array.isArray(next.data)) {
-      data = dedupeJsonValues([...current.data, ...next.data]);
-    } else if (isPlainObject(current.data) && isPlainObject(next.data)) {
-      data = { ...current.data, ...next.data };
-    }
-  }
-
-  return {
-    info,
-    warnings,
-    errors,
-    ...(data !== undefined ? { data } : {}),
-    ...(skipped ? { skipped } : {}),
-    ...(permissionsDiff ? { permissionsDiff } : {}),
-  };
-}
-
-function mergeAllCheckResults(current: AllCheckResults, next: AllCheckResults): AllCheckResults {
-  const merged: AllCheckResults = { ...current };
-
-  for (const [checkId, nextCheck] of Object.entries(next)) {
-    const currentCheck = merged[checkId];
-
-    if (!currentCheck) {
-      merged[checkId] = nextCheck;
-      continue;
-    }
-
-    merged[checkId] = {
-      name: currentCheck.name || nextCheck.name,
-      result: mergeCheckResult(currentCheck.result, nextCheck.result),
-    };
-  }
-
-  return merged;
 }
 
 /**
@@ -160,57 +62,6 @@ async function fetchBlockData(
     start: startBlock,
     end: endBlock,
   };
-}
-
-/**
- * @notice Process cross-chain destination simulations and run checks
- */
-async function processDestinationSimulations(
-  proposal: SimulationResult['proposal'],
-  deps: ProposalData,
-  destinationSimulations: SimulationResult['destinationSimulations'],
-) {
-  const destinationChecks: Record<number, AllCheckResults> = {};
-
-  if (destinationSimulations) {
-    for (const destSim of destinationSimulations) {
-      if (destSim.status !== 'success' || !destSim.sim) {
-        continue;
-      }
-
-      if (!L2_CHECK_SUPPORTED_CHAIN_IDS.has(destSim.chainId)) {
-        console.log(
-          `[Index][L2_CHECK_SKIP] Skipping destination checks for unsupported chain ${destSim.chainId}.`,
-        );
-        continue;
-      }
-
-      try {
-        const l2Deps = {
-          ...deps,
-          publicClient: getClientForChain(destSim.chainId),
-          chainConfig: getChainConfig(destSim.chainId),
-        };
-        const checkResults = await runChecksForChain(
-          proposal,
-          destSim.sim,
-          l2Deps,
-          destSim.chainId,
-          destinationSimulations,
-        );
-        destinationChecks[destSim.chainId] = destinationChecks[destSim.chainId]
-          ? mergeAllCheckResults(destinationChecks[destSim.chainId], checkResults)
-          : checkResults;
-      } catch (error) {
-        console.error(
-          `[Index][L2_CHECK_FAILURE] Failed to run L2 checks for chain ${destSim.chainId}; continuing without destination checks for this chain.`,
-          error,
-        );
-      }
-    }
-  }
-
-  return destinationChecks;
 }
 
 /**
@@ -243,99 +94,32 @@ async function processSimulation(
   // The fallbackDeps parameter is only used if simulationResult.deps is undefined,
   // which shouldn't happen in normal operation
 
-  // Run checks for mainnet using runChecksForChain for consistency
+  // Run checks for mainnet using resilient check execution
   console.log(`  Running checks for proposal ${proposalId}...`);
-  const mainnetResults = await runChecksForChain(
+  const mainnetRun = await runChecksForChainWithDiagnostics(
     proposal,
     sim,
     finalDeps,
     1, // Mainnet chain ID
     destinationSimulations,
   );
+  const mainnetResults = mainnetRun.results;
 
   // Fetch block data
   const blocks = await fetchBlockData(proposal, latestBlock);
 
   // Process destination simulations and run checks
-  const destinationChecks = await processDestinationSimulations(
-    proposal,
-    finalDeps,
-    destinationSimulations,
-  );
+  const { destinationChecks, executionDiagnostics: destinationExecutionDiagnostics } =
+    await processDestinationChecks(proposal, finalDeps, destinationSimulations);
 
   // Build coverage data - include mainnet (chainId 1) and all L2 chains
   const coverageMetadata = buildCoverageMetadata();
   const coverage = buildCoverageFromResults(mainnetResults, coverageMetadata, 1);
 
-  // Merge L2 check coverage into the main coverage
-  for (const [chainIdStr, destResults] of Object.entries(destinationChecks)) {
-    const chainId = Number(chainIdStr);
-    const l2Coverage = buildCoverageFromResults(destResults, coverageMetadata, chainId);
-
-    // Append L2 checks to the main coverage
-    coverage.checks.push(...l2Coverage.checks);
-
-    // Aggregate summary totals
-    coverage.summary.total += l2Coverage.summary.total;
-    coverage.summary.ran += l2Coverage.summary.ran;
-    coverage.summary.skipped += l2Coverage.summary.skipped;
-    coverage.summary.failed += l2Coverage.summary.failed;
-    coverage.summary.inferredSkips += l2Coverage.summary.inferredSkips;
-  }
-
-  // Ensure every destination chain appears in coverage, even when checks did not run.
-  const coveredChainIds = new Set(Object.keys(destinationChecks).map((id) => Number(id)));
-  const simsByChain = new Map<
-    number,
-    Array<NonNullable<SimulationResult['destinationSimulations']>[number]>
-  >();
-  for (const destinationSim of destinationSimulations ?? []) {
-    const list = simsByChain.get(destinationSim.chainId) ?? [];
-    list.push(destinationSim);
-    simsByChain.set(destinationSim.chainId, list);
-  }
-
-  for (const [chainId, chainSims] of simsByChain.entries()) {
-    if (coveredChainIds.has(chainId)) continue;
-
-    let status: 'skipped' | 'failed' = 'skipped';
-    let skipReason: string | undefined;
-
-    const failures = chainSims.filter((sim) => sim.status === 'failure');
-    const skips = chainSims.filter((sim) => sim.status === 'skipped');
-    const successes = chainSims.filter((sim) => sim.status === 'success');
-
-    if (failures.length > 0) {
-      status = 'failed';
-      const reasons = failures.map((sim) => sim.error).filter(Boolean);
-      skipReason = reasons.length > 0 ? reasons.join(' | ') : 'Destination simulation failed.';
-    } else if (!L2_CHECK_SUPPORTED_CHAIN_IDS.has(chainId)) {
-      status = 'skipped';
-      skipReason = `L2 checks are not supported for chain ${chainId}.`;
-    } else if (skips.length > 0) {
-      status = 'skipped';
-      const reasons = skips.map((sim) => sim.error).filter(Boolean);
-      skipReason = reasons.length > 0 ? reasons.join(' | ') : 'Destination simulation skipped.';
-    } else if (successes.length > 0) {
-      status = 'failed';
-      skipReason =
-        'Destination simulation succeeded but no L2 checks were recorded for this chain.';
-    } else {
-      status = 'skipped';
-      skipReason = 'No destination simulation result was available for this chain.';
-    }
-
-    coverage.checks.push({
-      checkId: 'crossChainDestination',
-      checkName: 'Cross-chain destination simulation status',
-      status,
-      skipReason,
-      chainId,
-    });
-    coverage.summary.total += 1;
-    if (status === 'skipped') coverage.summary.skipped += 1;
-    else coverage.summary.failed += 1;
-  }
+  appendDestinationCoverageDiagnostics(coverage, destinationChecks, destinationSimulations, {
+    1: mainnetRun.diagnostics,
+    ...destinationExecutionDiagnostics,
+  });
 
   // Log coverage summary
   console.log(

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -195,6 +195,7 @@ function getSimulationContractLabel(
 async function buildCrossChainPreview(
   destinationSimulations: NonNullable<SimulationResult['destinationSimulations']>,
   destinationChecks?: Record<number, AllCheckResults>,
+  coverage?: CoverageData,
 ): Promise<StructuredSimulationReport['crossChain']> {
   const messages = await Promise.all(
     destinationSimulations.map(async (dest) => {
@@ -234,31 +235,106 @@ async function buildCrossChainPreview(
     }),
   );
 
-  const chains =
-    destinationChecks && Object.keys(destinationChecks).length > 0
-      ? Object.entries(destinationChecks)
-          .map(([chainIdStr, checks]) => {
-            const chainId = Number(chainIdStr);
+  const destinationChainReports = new Map<
+    number,
+    {
+      chainId: number;
+      chainName: string;
+      blockExplorerBaseUrl?: string;
+      status: 'success' | 'warning' | 'error' | 'inconclusive';
+      checks: SimulationCheck[];
+    }
+  >();
 
-            let blockExplorerBaseUrl = 'https://etherscan.io';
-            try {
-              blockExplorerBaseUrl = getChainConfig(chainId).blockExplorer.baseUrl;
-            } catch {
-              // Ignore unknown chain configs.
-            }
+  for (const [chainIdStr, checks] of Object.entries(destinationChecks ?? {})) {
+    const chainId = Number(chainIdStr);
 
-            return {
-              chainId,
-              chainName: getChainName(chainId),
-              blockExplorerBaseUrl,
-              status: getStatusForChecks(checks),
-              checks: formatChecksForStructuredReport(checks, chainId),
-            };
-          })
-          .sort((a, b) => a.chainId - b.chainId)
-      : undefined;
+    let blockExplorerBaseUrl = 'https://etherscan.io';
+    try {
+      blockExplorerBaseUrl = getChainConfig(chainId).blockExplorer.baseUrl;
+    } catch {
+      // Ignore unknown chain configs.
+    }
 
-  return { messages, destinationChains: chains };
+    destinationChainReports.set(chainId, {
+      chainId,
+      chainName: getChainName(chainId),
+      blockExplorerBaseUrl,
+      status: getStatusForChecks(checks, chainId, coverage),
+      checks: formatChecksForStructuredReport(checks, chainId),
+    });
+  }
+
+  for (const [chainIdStr, diagnostics] of Object.entries(coverage?.executionDiagnostics ?? {})) {
+    const chainId = Number(chainIdStr);
+    if (chainId === 1 || !diagnostics.partial) continue;
+
+    const partialReason =
+      diagnostics.partialReason ?? 'Destination checks were partial/inconclusive.';
+    const existing = destinationChainReports.get(chainId);
+
+    if (existing) {
+      const hasExecutionSummary = existing.checks.some(
+        (check) => check.checkId === 'destinationCheckExecution',
+      );
+      if (!hasExecutionSummary) {
+        existing.checks.push({
+          checkId: 'destinationCheckExecution',
+          chainId,
+          title: 'Destination check execution diagnostics',
+          status: 'inconclusive',
+          skipReason: partialReason,
+          details: `**Inconclusive**: ${partialReason}`,
+          info: [],
+          warnings: [],
+          errors: [],
+          data: {
+            executionDiagnostics: diagnostics,
+          },
+        });
+      }
+      existing.status = 'inconclusive';
+      destinationChainReports.set(chainId, existing);
+      continue;
+    }
+
+    let blockExplorerBaseUrl = 'https://etherscan.io';
+    try {
+      blockExplorerBaseUrl = getChainConfig(chainId).blockExplorer.baseUrl;
+    } catch {
+      // Ignore unknown chain configs.
+    }
+
+    destinationChainReports.set(chainId, {
+      chainId,
+      chainName: getChainName(chainId),
+      blockExplorerBaseUrl,
+      status: 'inconclusive',
+      checks: [
+        {
+          checkId: 'destinationCheckExecution',
+          chainId,
+          title: 'Destination check execution diagnostics',
+          status: 'inconclusive',
+          skipReason: partialReason,
+          details: `**Inconclusive**: ${partialReason}`,
+          info: [],
+          warnings: [],
+          errors: [],
+          data: {
+            executionDiagnostics: diagnostics,
+          },
+        },
+      ],
+    });
+  }
+
+  const chains = Array.from(destinationChainReports.values()).sort((a, b) => a.chainId - b.chainId);
+
+  return {
+    messages,
+    ...(chains.length > 0 ? { destinationChains: chains } : {}),
+  };
 }
 
 // --- Repository and Tenderly utilities ---
@@ -689,17 +765,65 @@ function extractCalldata(
   return undefined;
 }
 
-function getStatusForChecks(value: AllCheckResults): 'success' | 'warning' | 'error' {
+function getExecutionFailureData(
+  result: AllCheckResults[string]['result'],
+): { reason?: string } | undefined {
+  const data = result.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return undefined;
+
+  const executionFailure = Reflect.get(data, 'executionFailure');
+  if (
+    !executionFailure ||
+    typeof executionFailure !== 'object' ||
+    Array.isArray(executionFailure)
+  ) {
+    return undefined;
+  }
+
+  const reason = Reflect.get(executionFailure, 'reason');
+  return typeof reason === 'string' ? { reason } : {};
+}
+
+function isChainMarkedPartial(
+  chainId: number | undefined,
+  coverage?: CoverageData,
+): { partial: boolean; reason?: string } {
+  if (chainId == null || !coverage?.executionDiagnostics) {
+    return { partial: false };
+  }
+
+  const diagnostics = coverage.executionDiagnostics[chainId];
+  if (!diagnostics?.partial) {
+    return { partial: false };
+  }
+
+  return {
+    partial: true,
+    reason: diagnostics.partialReason,
+  };
+}
+
+function getStatusForChecks(
+  value: AllCheckResults,
+  chainId?: number,
+  coverage?: CoverageData,
+): 'success' | 'warning' | 'error' | 'inconclusive' {
   let hasErrors = false;
   let hasWarnings = false;
+  let hasInconclusive = false;
 
   for (const checkId in value) {
     const { result } = value[checkId];
     if (result.errors.length > 0) hasErrors = true;
     if (result.warnings.length > 0) hasWarnings = true;
+    if (getExecutionFailureData(result)) hasInconclusive = true;
   }
 
+  const partialChain = isChainMarkedPartial(chainId, coverage);
+  if (partialChain.partial) hasInconclusive = true;
+
   if (hasErrors) return 'error';
+  if (hasInconclusive) return 'inconclusive';
   if (hasWarnings) return 'warning';
   return 'success';
 }
@@ -711,11 +835,15 @@ function formatChecksForStructuredReport(
   return Object.entries(value).map(([checkId, check]) => {
     const { name, result } = check;
     const { errors, warnings, info, skipped } = result;
+    const executionFailure = getExecutionFailureData(result);
 
-    let checkStatus: 'passed' | 'warning' | 'failed' | 'skipped' = 'passed';
+    let checkStatus: 'passed' | 'warning' | 'failed' | 'skipped' | 'inconclusive' = 'passed';
     let skipReason: string | undefined;
 
-    if (skipped) {
+    if (executionFailure) {
+      checkStatus = 'inconclusive';
+      skipReason = skipped?.reason ?? executionFailure.reason;
+    } else if (skipped) {
       checkStatus = 'skipped';
       skipReason = skipped.reason;
     } else if (errors.length > 0) {
@@ -725,6 +853,7 @@ function formatChecksForStructuredReport(
     }
 
     const details = [
+      ...(executionFailure?.reason ? [`**Inconclusive**: ${executionFailure.reason}`] : []),
       ...(skipped ? [`**Skipped**: ${skipped.reason}`] : []),
       ...errors.map((msg) => `**Error**: ${msg}`),
       ...warnings.map((msg) => `**Warning**: ${msg}`),
@@ -787,6 +916,7 @@ function generateStructuredReport(
   simulationId?: string,
   simulation?: TenderlySimulation,
   destinationChecks?: Record<number, AllCheckResults>,
+  coverage?: CoverageData,
   proposalState?: string,
 ): StructuredSimulationReport {
   // Validate required fields
@@ -809,14 +939,25 @@ function generateStructuredReport(
   // Determine overall status
   let status: 'success' | 'warning' | 'error' | 'inconclusive' = 'success';
 
-  // Set status based on conditions (skips are informational and do not make the report inconclusive)
-  status = getStatusForChecks(checks);
-
-  // Format checks
-  const formattedChecks: SimulationCheck[] = formatChecksForStructuredReport(checks, chainId ?? 1);
-
   // Get chain configuration for explorer URL
   const targetChainId = chainId ?? 1; // Default to mainnet
+
+  // Set status from source-chain checks first.
+  status = getStatusForChecks(checks, targetChainId, coverage);
+
+  const partialDestinationChains = Object.entries(coverage?.executionDiagnostics ?? {})
+    .filter(
+      ([chainIdStr, diagnostics]) => Number(chainIdStr) !== targetChainId && diagnostics.partial,
+    )
+    .map(([chainIdStr]) => Number(chainIdStr));
+
+  if (status !== 'error' && partialDestinationChains.length > 0) {
+    status = 'inconclusive';
+  }
+
+  // Format checks
+  const formattedChecks: SimulationCheck[] = formatChecksForStructuredReport(checks, targetChainId);
+
   let blockExplorerBaseUrl = 'https://etherscan.io';
   try {
     const chainConfig = getChainConfig(targetChainId);
@@ -854,48 +995,129 @@ function generateStructuredReport(
       ? 'completed successfully'
       : status === 'warning'
         ? 'completed with warnings'
-        : 'completed with errors';
+        : status === 'inconclusive'
+          ? 'completed with inconclusive checks'
+          : 'completed with errors';
 
   const mainStateChanges = extractStateChanges(checks);
   const mainEvents = extractEvents(checks);
+
+  const destinationChainReports = new Map<
+    number,
+    NonNullable<StructuredSimulationReport['chainReports']>[number]
+  >();
+
+  for (const [chainIdStr, destinationResults] of Object.entries(destinationChecks ?? {})) {
+    const destChainId = Number(chainIdStr);
+
+    let destBlockExplorerBaseUrl = 'https://etherscan.io';
+    try {
+      destBlockExplorerBaseUrl = getChainConfig(destChainId).blockExplorer.baseUrl;
+    } catch {
+      // Ignore unknown chain configs.
+    }
+
+    destinationChainReports.set(destChainId, {
+      chainId: destChainId,
+      chainName: getChainName(destChainId),
+      blockExplorerBaseUrl: destBlockExplorerBaseUrl,
+      status: getStatusForChecks(destinationResults, destChainId, coverage),
+      checks: formatChecksForStructuredReport(destinationResults, destChainId),
+      stateChanges: extractStateChanges(destinationResults),
+      events: extractEvents(destinationResults),
+    });
+  }
+
+  for (const [chainIdStr, diagnostics] of Object.entries(coverage?.executionDiagnostics ?? {})) {
+    const destChainId = Number(chainIdStr);
+    if (destChainId === targetChainId || !diagnostics.partial) continue;
+
+    const partialReason =
+      diagnostics.partialReason ?? 'Destination checks were partial/inconclusive.';
+    const existing = destinationChainReports.get(destChainId);
+
+    if (existing) {
+      existing.status = 'inconclusive';
+      const hasExecutionSummary = existing.checks.some(
+        (check) => check.checkId === 'destinationCheckExecution',
+      );
+      if (!hasExecutionSummary) {
+        existing.checks.push({
+          checkId: 'destinationCheckExecution',
+          chainId: destChainId,
+          title: 'Destination check execution diagnostics',
+          status: 'inconclusive',
+          skipReason: partialReason,
+          details: `**Inconclusive**: ${partialReason}`,
+          info: [],
+          warnings: [],
+          errors: [],
+          data: {
+            executionDiagnostics: diagnostics,
+          },
+        });
+      }
+      destinationChainReports.set(destChainId, existing);
+      continue;
+    }
+
+    let destBlockExplorerBaseUrl = 'https://etherscan.io';
+    try {
+      destBlockExplorerBaseUrl = getChainConfig(destChainId).blockExplorer.baseUrl;
+    } catch {
+      // Ignore unknown chain configs.
+    }
+
+    destinationChainReports.set(destChainId, {
+      chainId: destChainId,
+      chainName: getChainName(destChainId),
+      blockExplorerBaseUrl: destBlockExplorerBaseUrl,
+      status: 'inconclusive',
+      checks: [
+        {
+          checkId: 'destinationCheckExecution',
+          chainId: destChainId,
+          title: 'Destination check execution diagnostics',
+          status: 'inconclusive',
+          skipReason: partialReason,
+          details: `**Inconclusive**: ${partialReason}`,
+          info: [],
+          warnings: [],
+          errors: [],
+          data: {
+            executionDiagnostics: diagnostics,
+          },
+        },
+      ],
+      stateChanges: [],
+      events: [],
+    });
+  }
 
   const chainReports: StructuredSimulationReport['chainReports'] = [
     {
       chainId: targetChainId,
       chainName: getChainName(targetChainId),
       blockExplorerBaseUrl,
-      status: getStatusForChecks(checks),
+      status: getStatusForChecks(checks, targetChainId, coverage),
       checks: formattedChecks,
       stateChanges: mainStateChanges,
       events: mainEvents,
     },
-    ...Object.entries(destinationChecks ?? {}).map(([chainIdStr, destChecks]) => {
-      const destChainId = Number(chainIdStr);
-
-      let destBlockExplorerBaseUrl = 'https://etherscan.io';
-      try {
-        destBlockExplorerBaseUrl = getChainConfig(destChainId).blockExplorer.baseUrl;
-      } catch {
-        // Ignore unknown chain configs.
-      }
-
-      return {
-        chainId: destChainId,
-        chainName: getChainName(destChainId),
-        blockExplorerBaseUrl: destBlockExplorerBaseUrl,
-        status: getStatusForChecks(destChecks),
-        checks: formatChecksForStructuredReport(destChecks, destChainId),
-        stateChanges: extractStateChanges(destChecks),
-        events: extractEvents(destChecks),
-      };
-    }),
+    ...Array.from(destinationChainReports.values()).sort((a, b) => a.chainId - b.chainId),
   ];
+
+  const partialReasonText = partialDestinationChains.length
+    ? ` Partial destination checks on chain(s): ${partialDestinationChains
+        .map((destChainId) => `${getChainName(destChainId)} (${destChainId})`)
+        .join(', ')}.`
+    : '';
 
   return {
     title,
     proposalText,
     status,
-    summary: `${plainLanguageSummary}. Simulation ${statusText}.`,
+    summary: `${plainLanguageSummary}. Simulation ${statusText}.${partialReasonText}`,
     checks: formattedChecks,
     stateChanges: mainStateChanges,
     events: mainEvents,
@@ -987,6 +1209,7 @@ export function writeSimulationResultsJson(params: WriteSimulationResultsJsonPar
         simulationId,
         simulation,
         destinationChecks,
+        coverage,
         proposalState,
       );
 
@@ -1107,6 +1330,7 @@ export async function generateAndSaveReports(params: GenerateReportsParams) {
     simulation?.simulation?.id,
     simulation,
     destinationChecks,
+    coverage,
     proposalState,
   );
 
@@ -1151,6 +1375,7 @@ export async function generateAndSaveReports(params: GenerateReportsParams) {
       structuredReport.crossChain = await buildCrossChainPreview(
         destinationSimulations,
         destinationChecks,
+        coverage,
       );
     } catch (error) {
       console.warn('[Report] Failed to build cross-chain preview:', error);
@@ -1310,25 +1535,31 @@ function getOverallStatusFromChecks(checks: AllCheckResults): {
   skipped: Array<{ checkId: string; name: string; reason: string }>;
   warningCount: number;
   errorCount: number;
+  inconclusiveCount: number;
 } {
   const skipped: Array<{ checkId: string; name: string; reason: string }> = [];
   let warningCount = 0;
   let errorCount = 0;
+  let inconclusiveCount = 0;
 
   for (const checkId in checks) {
     const { name, result } = checks[checkId];
     if (result.skipped) skipped.push({ checkId, name, reason: result.skipped.reason });
+    if (getExecutionFailureData(result)) inconclusiveCount += 1;
     warningCount += result.warnings.length;
     errorCount += result.errors.length;
   }
 
   if (errorCount > 0) {
-    return { status: 'error', skipped, warningCount, errorCount };
+    return { status: 'error', skipped, warningCount, errorCount, inconclusiveCount };
+  }
+  if (inconclusiveCount > 0) {
+    return { status: 'inconclusive', skipped, warningCount, errorCount, inconclusiveCount };
   }
   if (warningCount > 0) {
-    return { status: 'warning', skipped, warningCount, errorCount };
+    return { status: 'warning', skipped, warningCount, errorCount, inconclusiveCount };
   }
-  return { status: 'success', skipped, warningCount, errorCount };
+  return { status: 'success', skipped, warningCount, errorCount, inconclusiveCount };
 }
 
 async function formatExecutiveSummary(
@@ -1337,7 +1568,8 @@ async function formatExecutiveSummary(
   destinationSimulations?: SimulationResult['destinationSimulations'],
   destinationChecks?: Record<number, AllCheckResults>,
 ): Promise<string> {
-  const { status, skipped, warningCount, errorCount } = getOverallStatusFromChecks(checks);
+  const { status, skipped, warningCount, errorCount, inconclusiveCount } =
+    getOverallStatusFromChecks(checks);
 
   const statusLabel =
     status === 'success'
@@ -1346,7 +1578,7 @@ async function formatExecutiveSummary(
         ? 'WARNING'
         : status === 'error'
           ? 'ERROR'
-          : 'SUCCESS';
+          : 'INCONCLUSIVE';
 
   const skippedText =
     skipped.length > 0
@@ -1364,7 +1596,7 @@ async function formatExecutiveSummary(
 
   return [
     `- Action: ${actionSummary}`,
-    `- Result: **${statusLabel}** (errors: ${errorCount}, warnings: ${warningCount}, skipped: ${skipped.length})${skippedText}`,
+    `- Result: **${statusLabel}** (errors: ${errorCount}, warnings: ${warningCount}, inconclusive: ${inconclusiveCount}, skipped: ${skipped.length})${skippedText}`,
     ...(crossChainSummary ? [`- Cross-chain: ${crossChainSummary}`] : []),
   ].join('\n');
 }

--- a/run-checks.ts
+++ b/run-checks.ts
@@ -8,10 +8,15 @@ import ALL_CHECKS from './checks';
 import { generateAndSaveReports } from './presentation/report';
 import type {
   AllCheckResults,
+  ChainExecutionDiagnostics,
   CheckCoverage,
+  CheckResult,
+  CheckRetryDiagnostic,
   CoverageData,
   CoverageMetadata,
+  FailedCheckExecutionDiagnostic,
   Message,
+  ProposalCheck,
   ProposalData,
   ProposalEvent,
   SimulationConfig,
@@ -44,6 +49,45 @@ const SKIP_PATTERNS = [
   /only the timelock and governor/i,
 ];
 
+const MAX_CHECK_RETRIES = 1;
+
+const RETRYABLE_ERROR_PATTERNS = [
+  /ETIMEDOUT/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /ENOTFOUND/i,
+  /EAI_AGAIN/i,
+  /network/i,
+  /fetch failed/i,
+  /timeout/i,
+  /rate limit/i,
+  /429/i,
+  /502/i,
+  /503/i,
+  /504/i,
+  /rpc/i,
+  /etherscan/i,
+  /sourcify/i,
+  /tenderly/i,
+  /gateway/i,
+  /temporar/i,
+  /socket hang up/i,
+];
+
+export const L2_CHECK_SUPPORTED_CHAIN_IDS = new Set([
+  10, // Optimism
+  8453, // Base
+  42161, // Arbitrum
+  130, // Unichain
+  57073, // Ink
+  1868, // Soneium
+  60808, // Bob
+  196, // X Layer
+  42220, // Celo
+  480, // World Chain
+  7777777, // Zora
+]);
+
 /**
  * Infer if a check was skipped based on info messages (heuristic fallback)
  */
@@ -57,6 +101,586 @@ function inferSkipFromInfo(info: Message[]): string | null {
   if (!allSkipLike) return null;
 
   return info[0] ?? null;
+}
+
+const CHECK_EXECUTION_ORDER = [
+  'checkStateChanges',
+  'checkLogs',
+  'checkProxyResolution',
+  'checkPermissionDiff',
+  'checkEthBalanceChanges',
+  'checkTreasuryMovement',
+  'checkDecodeCalldata',
+  'checkTargetsVerifiedOnBlockExplorer',
+  'checkTouchedContractsVerifiedOnBlockExplorer',
+  'checkTargetsNoSelfdestruct',
+  'checkTouchedContractsNoSelfdestruct',
+  // Preserve explicit dependency ordering.
+  'checkSolc',
+  'checkSlither',
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (isRecord(error)) {
+    const message = error.message;
+    if (typeof message === 'string') return message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function isRetryableCheckFailure(error: unknown): boolean {
+  const message = toErrorMessage(error);
+  if (RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+    return true;
+  }
+
+  if (isRecord(error)) {
+    const code = error.code;
+    if (typeof code === 'string') {
+      const normalized = code.toUpperCase();
+      if (
+        normalized === 'ETIMEDOUT' ||
+        normalized === 'ECONNRESET' ||
+        normalized === 'ECONNREFUSED' ||
+        normalized === 'ENOTFOUND' ||
+        normalized === 'EAI_AGAIN'
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function buildInconclusiveCheckResult(
+  checkId: string,
+  checkName: string,
+  reason: string,
+  retries: number,
+  retryable: boolean,
+): CheckResult {
+  return {
+    info: [],
+    warnings: [],
+    errors: [],
+    skipped: {
+      reason: `Inconclusive: ${reason}`,
+    },
+    data: {
+      executionFailure: {
+        checkId,
+        checkName,
+        reason,
+        retries,
+        retryable,
+      },
+    },
+  };
+}
+
+type CheckExecutionRunResult = {
+  result: CheckResult;
+  failedDiagnostic?: FailedCheckExecutionDiagnostic;
+  retryDiagnostic?: CheckRetryDiagnostic;
+};
+
+async function runCheckWithIsolationAndRetry(
+  checkId: string,
+  check: ProposalCheck,
+  proposal: ProposalEvent,
+  sim: TenderlySimulation,
+  deps: ProposalData,
+  l2Simulations?: {
+    chainId: number;
+    sim: TenderlySimulation;
+  }[],
+): Promise<CheckExecutionRunResult> {
+  let retries = 0;
+  let lastErrorMessage = '';
+  let retryable = false;
+
+  while (retries <= MAX_CHECK_RETRIES) {
+    try {
+      const result = await check.checkProposal(proposal, sim, deps, l2Simulations);
+      if (retries > 0) {
+        return {
+          result,
+          retryDiagnostic: {
+            checkId,
+            checkName: check.name,
+            retries,
+            outcome: 'success',
+            lastError: lastErrorMessage,
+          },
+        };
+      }
+      return { result };
+    } catch (error) {
+      lastErrorMessage = toErrorMessage(error);
+      retryable = isRetryableCheckFailure(error);
+
+      if (retryable && retries < MAX_CHECK_RETRIES) {
+        retries += 1;
+        continue;
+      }
+
+      const failureReason = `Check execution failed (${checkId}): ${lastErrorMessage}`;
+      return {
+        result: buildInconclusiveCheckResult(
+          checkId,
+          check.name,
+          failureReason,
+          retries,
+          retryable,
+        ),
+        failedDiagnostic: {
+          checkId,
+          checkName: check.name,
+          reason: failureReason,
+          retryable,
+          retries,
+        },
+        ...(retries > 0
+          ? {
+              retryDiagnostic: {
+                checkId,
+                checkName: check.name,
+                retries,
+                outcome: 'failed',
+                lastError: lastErrorMessage,
+              },
+            }
+          : {}),
+      };
+    }
+  }
+
+  const unexpectedReason = `Unexpected retry loop termination for ${checkId}`;
+  return {
+    result: buildInconclusiveCheckResult(checkId, check.name, unexpectedReason, retries, retryable),
+    failedDiagnostic: {
+      checkId,
+      checkName: check.name,
+      reason: unexpectedReason,
+      retryable,
+      retries,
+    },
+  };
+}
+
+function createEmptyChainExecutionDiagnostics(chainId: number): ChainExecutionDiagnostics {
+  return {
+    chainId,
+    attemptedChecks: [],
+    failedChecks: [],
+    retries: [],
+    partial: false,
+  };
+}
+
+function dedupeStrings(messages: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const message of messages) {
+    if (seen.has(message)) continue;
+    seen.add(message);
+    deduped.push(message);
+  }
+  return deduped;
+}
+
+function dedupeJsonValues<T>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+  for (const item of items) {
+    const key = JSON.stringify(item, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeCheckResult(current: CheckResult, next: CheckResult): CheckResult {
+  const info = dedupeStrings([...current.info, ...next.info]);
+  const warnings = dedupeStrings([...current.warnings, ...next.warnings]);
+  const errors = dedupeStrings([...current.errors, ...next.errors]);
+
+  const skippedReasons = [current.skipped?.reason, next.skipped?.reason].filter(
+    (reason): reason is string => Boolean(reason),
+  );
+  const skipped =
+    current.skipped && next.skipped && skippedReasons.length > 0
+      ? { reason: dedupeStrings(skippedReasons).join(' | ') }
+      : undefined;
+
+  const permissionsDiffMerged = dedupeJsonValues([
+    ...(current.permissionsDiff ?? []),
+    ...(next.permissionsDiff ?? []),
+  ]);
+  const permissionsDiff = permissionsDiffMerged.length > 0 ? permissionsDiffMerged : undefined;
+
+  let data = current.data ?? next.data;
+  if (current.data !== undefined && next.data !== undefined) {
+    if (Array.isArray(current.data) && Array.isArray(next.data)) {
+      data = dedupeJsonValues([...current.data, ...next.data]);
+    } else if (isPlainObject(current.data) && isPlainObject(next.data)) {
+      data = { ...current.data, ...next.data };
+    }
+  }
+
+  return {
+    info,
+    warnings,
+    errors,
+    ...(data !== undefined ? { data } : {}),
+    ...(skipped ? { skipped } : {}),
+    ...(permissionsDiff ? { permissionsDiff } : {}),
+  };
+}
+
+export function mergeAllCheckResults(
+  current: AllCheckResults,
+  next: AllCheckResults,
+): AllCheckResults {
+  const merged: AllCheckResults = { ...current };
+
+  for (const [checkId, nextCheck] of Object.entries(next)) {
+    const currentCheck = merged[checkId];
+
+    if (!currentCheck) {
+      merged[checkId] = nextCheck;
+      continue;
+    }
+
+    merged[checkId] = {
+      name: currentCheck.name || nextCheck.name,
+      result: mergeCheckResult(currentCheck.result, nextCheck.result),
+    };
+  }
+
+  return merged;
+}
+
+function mergeChainExecutionDiagnostics(
+  current: ChainExecutionDiagnostics,
+  next: ChainExecutionDiagnostics,
+): ChainExecutionDiagnostics {
+  const retryEntries = dedupeJsonValues([...current.retries, ...next.retries]);
+  const failedChecks = dedupeJsonValues([...current.failedChecks, ...next.failedChecks]);
+  const attemptedChecks = dedupeStrings([...current.attemptedChecks, ...next.attemptedChecks]);
+
+  const reasons = [current.partialReason, next.partialReason].filter((reason): reason is string =>
+    Boolean(reason),
+  );
+
+  return {
+    chainId: current.chainId,
+    attemptedChecks,
+    failedChecks,
+    retries: retryEntries,
+    partial: current.partial || next.partial,
+    ...(reasons.length > 0 ? { partialReason: dedupeStrings(reasons).join(' | ') } : {}),
+  };
+}
+
+function addCoverageEntry(
+  coverage: CoverageData,
+  status: 'skipped' | 'failed',
+  chainId: number,
+  skipReason: string,
+): void {
+  coverage.checks.push({
+    checkId: 'crossChainDestination',
+    checkName: 'Cross-chain destination simulation status',
+    status,
+    skipReason,
+    chainId,
+  });
+  coverage.summary.total += 1;
+  if (status === 'skipped') coverage.summary.skipped += 1;
+  else coverage.summary.failed += 1;
+}
+
+export function mergeCoverageForChain(coverage: CoverageData, nextCoverage: CoverageData): void {
+  coverage.checks.push(...nextCoverage.checks);
+  coverage.summary.total += nextCoverage.summary.total;
+  coverage.summary.ran += nextCoverage.summary.ran;
+  coverage.summary.skipped += nextCoverage.summary.skipped;
+  coverage.summary.failed += nextCoverage.summary.failed;
+  coverage.summary.inferredSkips += nextCoverage.summary.inferredSkips;
+}
+
+export type ChainCheckRun = {
+  results: AllCheckResults;
+  diagnostics: ChainExecutionDiagnostics;
+};
+
+export type DestinationChecksProcessingResult = {
+  destinationChecks: Record<number, AllCheckResults>;
+  executionDiagnostics: Record<number, ChainExecutionDiagnostics>;
+};
+
+export async function runChecksForChainWithDiagnostics(
+  proposal: ProposalEvent,
+  sim: TenderlySimulation,
+  deps: ProposalData,
+  chainId: number,
+  allL2Simulations?: SimulationResult['destinationSimulations'],
+  checksOverride?: Record<string, ProposalCheck>,
+): Promise<ChainCheckRun> {
+  const results: AllCheckResults = {};
+  const chainConfig = getChainConfig(chainId);
+
+  const depsWithConfig = {
+    ...deps,
+    chainConfig,
+  };
+
+  const l2Simulations =
+    chainId !== 1 && allL2Simulations
+      ? allL2Simulations
+          .filter((simulation): simulation is typeof simulation & { sim: TenderlySimulation } =>
+            Boolean(simulation.sim),
+          )
+          .map((simulation) => ({ chainId: simulation.chainId, sim: simulation.sim }))
+      : undefined;
+
+  const diagnostics = createEmptyChainExecutionDiagnostics(chainId);
+  const checksSource = checksOverride ?? ALL_CHECKS;
+
+  for (const checkId of CHECK_EXECUTION_ORDER) {
+    const check = checksSource[checkId];
+    if (!check) continue;
+
+    diagnostics.attemptedChecks.push(checkId);
+
+    const execution = await runCheckWithIsolationAndRetry(
+      checkId,
+      check,
+      proposal,
+      sim,
+      depsWithConfig,
+      l2Simulations,
+    );
+
+    results[checkId] = {
+      name: check.name,
+      result: execution.result,
+    };
+
+    if (execution.failedDiagnostic) {
+      diagnostics.failedChecks.push(execution.failedDiagnostic);
+    }
+    if (execution.retryDiagnostic) {
+      diagnostics.retries.push(execution.retryDiagnostic);
+    }
+  }
+
+  if (diagnostics.failedChecks.length > 0) {
+    diagnostics.partial = true;
+    const failedCheckIds = diagnostics.failedChecks.map((entry) => entry.checkId);
+    diagnostics.partialReason = `Partial check execution: ${failedCheckIds.join(', ')} failed to complete.`;
+  }
+
+  return { results, diagnostics };
+}
+
+export async function processDestinationChecks(
+  proposal: ProposalEvent,
+  deps: ProposalData,
+  destinationSimulations: SimulationResult['destinationSimulations'],
+): Promise<DestinationChecksProcessingResult> {
+  const destinationChecks: Record<number, AllCheckResults> = {};
+  const executionDiagnostics: Record<number, ChainExecutionDiagnostics> = {};
+
+  for (const destinationSimulation of destinationSimulations ?? []) {
+    const chainId = destinationSimulation.chainId;
+
+    if (destinationSimulation.status !== 'success' || !destinationSimulation.sim) {
+      continue;
+    }
+
+    const chainDiagnostics =
+      executionDiagnostics[chainId] ?? createEmptyChainExecutionDiagnostics(chainId);
+
+    if (!L2_CHECK_SUPPORTED_CHAIN_IDS.has(chainId)) {
+      chainDiagnostics.partial = true;
+      chainDiagnostics.partialReason = `Destination simulation succeeded but L2 checks are not supported for chain ${chainId}.`;
+      executionDiagnostics[chainId] = chainDiagnostics;
+      continue;
+    }
+
+    try {
+      const l2Deps: ProposalData = {
+        ...deps,
+        publicClient: getClientForChain(chainId),
+        chainConfig: getChainConfig(chainId),
+      };
+
+      const chainRun = await runChecksForChainWithDiagnostics(
+        proposal,
+        destinationSimulation.sim,
+        l2Deps,
+        chainId,
+        destinationSimulations,
+      );
+
+      destinationChecks[chainId] = destinationChecks[chainId]
+        ? mergeAllCheckResults(destinationChecks[chainId], chainRun.results)
+        : chainRun.results;
+
+      executionDiagnostics[chainId] = executionDiagnostics[chainId]
+        ? mergeChainExecutionDiagnostics(executionDiagnostics[chainId], chainRun.diagnostics)
+        : chainRun.diagnostics;
+    } catch (error) {
+      const reason = toErrorMessage(error);
+      chainDiagnostics.partial = true;
+      chainDiagnostics.partialReason = `Destination checks failed to start for chain ${chainId}: ${reason}`;
+      executionDiagnostics[chainId] = chainDiagnostics;
+      console.error(
+        `[Checks][L2_CHECK_FAILURE] Failed to run destination checks for chain ${chainId}; continuing with partial report.`,
+        error,
+      );
+    }
+  }
+
+  for (const destinationSimulation of destinationSimulations ?? []) {
+    const chainId = destinationSimulation.chainId;
+    if (destinationSimulation.status !== 'success') continue;
+
+    const chainDiagnostics = executionDiagnostics[chainId];
+    if (!chainDiagnostics) continue;
+
+    if (chainDiagnostics.attemptedChecks.length === 0) {
+      chainDiagnostics.partial = true;
+      if (!chainDiagnostics.partialReason) {
+        chainDiagnostics.partialReason =
+          'Destination simulation succeeded but no destination checks were attempted.';
+      }
+    }
+  }
+
+  return {
+    destinationChecks,
+    executionDiagnostics,
+  };
+}
+
+export function appendDestinationCoverageDiagnostics(
+  coverage: CoverageData,
+  destinationChecks: Record<number, AllCheckResults>,
+  destinationSimulations: SimulationResult['destinationSimulations'],
+  executionDiagnostics: Record<number, ChainExecutionDiagnostics>,
+): void {
+  for (const [chainIdStr, destinationResults] of Object.entries(destinationChecks)) {
+    const chainId = Number(chainIdStr);
+    const l2Coverage = buildCoverageFromResults(destinationResults, coverage.metadata, chainId);
+    mergeCoverageForChain(coverage, l2Coverage);
+  }
+
+  const chainsWithDiagnosticEntry = new Set<number>();
+
+  for (const [chainIdStr, chainDiagnostics] of Object.entries(executionDiagnostics)) {
+    const chainId = Number(chainIdStr);
+    if (chainId === 1 || !chainDiagnostics.partial) continue;
+
+    const reason =
+      chainDiagnostics.partialReason ??
+      `Destination checks for chain ${chainId} are partial/inconclusive.`;
+    addCoverageEntry(coverage, 'failed', chainId, reason);
+    chainsWithDiagnosticEntry.add(chainId);
+  }
+
+  const coveredChainIds = new Set(Object.keys(destinationChecks).map((id) => Number(id)));
+  const simulationsByChain = new Map<
+    number,
+    Array<NonNullable<SimulationResult['destinationSimulations']>[number]>
+  >();
+
+  for (const destinationSimulation of destinationSimulations ?? []) {
+    const entries = simulationsByChain.get(destinationSimulation.chainId) ?? [];
+    entries.push(destinationSimulation);
+    simulationsByChain.set(destinationSimulation.chainId, entries);
+  }
+
+  for (const [chainId, chainSimulations] of simulationsByChain.entries()) {
+    if (coveredChainIds.has(chainId) || chainsWithDiagnosticEntry.has(chainId)) continue;
+
+    const failures = chainSimulations.filter((simulation) => simulation.status === 'failure');
+    const skips = chainSimulations.filter((simulation) => simulation.status === 'skipped');
+    const successes = chainSimulations.filter((simulation) => simulation.status === 'success');
+
+    if (failures.length > 0) {
+      const reasons = failures.map((simulation) => simulation.error).filter(Boolean);
+      addCoverageEntry(
+        coverage,
+        'failed',
+        chainId,
+        reasons.length > 0 ? reasons.join(' | ') : 'Destination simulation failed.',
+      );
+      continue;
+    }
+
+    if (!L2_CHECK_SUPPORTED_CHAIN_IDS.has(chainId)) {
+      addCoverageEntry(
+        coverage,
+        'skipped',
+        chainId,
+        `L2 checks are not supported for chain ${chainId}.`,
+      );
+      continue;
+    }
+
+    if (skips.length > 0) {
+      const reasons = skips.map((simulation) => simulation.error).filter(Boolean);
+      addCoverageEntry(
+        coverage,
+        'skipped',
+        chainId,
+        reasons.length > 0 ? reasons.join(' | ') : 'Destination simulation skipped.',
+      );
+      continue;
+    }
+
+    if (successes.length > 0) {
+      addCoverageEntry(
+        coverage,
+        'failed',
+        chainId,
+        'Destination simulation succeeded but no L2 checks were recorded for this chain.',
+      );
+      continue;
+    }
+
+    addCoverageEntry(
+      coverage,
+      'skipped',
+      chainId,
+      'No destination simulation result was available for this chain.',
+    );
+  }
+
+  if (Object.keys(executionDiagnostics).length > 0) {
+    coverage.executionDiagnostics = executionDiagnostics;
+  }
 }
 
 /**
@@ -231,90 +855,13 @@ export async function runChecksForChain(
   chainId: number,
   allL2Simulations?: SimulationResult['destinationSimulations'],
 ): Promise<AllCheckResults> {
-  const results: AllCheckResults = {};
-  const chainConfig = getChainConfig(chainId);
-
-  // Run all checks with chain-specific configuration
-  const depsWithConfig = {
-    ...deps,
-    chainConfig,
-  };
-
-  // For L2 checks, pass all L2 simulations
-  const l2Simulations =
-    chainId !== 1 && allL2Simulations
-      ? allL2Simulations.filter((s) => s.sim).map((s) => ({ chainId: s.chainId, sim: s.sim! }))
-      : undefined;
-
-  // Chain-agnostic checks
-  const CHAIN_AGNOSTIC_CHECK_IDS = [
-    'checkStateChanges',
-    'checkLogs',
-    'checkProxyResolution',
-    'checkPermissionDiff',
-    'checkEthBalanceChanges',
-    'checkTreasuryMovement',
-    'checkDecodeCalldata',
-  ] as const;
-
-  for (const checkId of CHAIN_AGNOSTIC_CHECK_IDS) {
-    results[checkId] = {
-      name: ALL_CHECKS[checkId].name,
-      result: await ALL_CHECKS[checkId].checkProposal(proposal, sim, depsWithConfig, l2Simulations),
-    };
-  }
-
-  // Chain-specific checks
-  results.checkTargetsVerifiedOnBlockExplorer = {
-    name: ALL_CHECKS.checkTargetsVerifiedOnBlockExplorer.name,
-    result: await ALL_CHECKS.checkTargetsVerifiedOnBlockExplorer.checkProposal(
-      proposal,
-      sim,
-      depsWithConfig,
-      l2Simulations,
-    ),
-  };
-  results.checkTouchedContractsVerifiedOnBlockExplorer = {
-    name: ALL_CHECKS.checkTouchedContractsVerifiedOnBlockExplorer.name,
-    result: await ALL_CHECKS.checkTouchedContractsVerifiedOnBlockExplorer.checkProposal(
-      proposal,
-      sim,
-      depsWithConfig,
-      l2Simulations,
-    ),
-  };
-  results.checkTargetsNoSelfdestruct = {
-    name: ALL_CHECKS.checkTargetsNoSelfdestruct.name,
-    result: await ALL_CHECKS.checkTargetsNoSelfdestruct.checkProposal(
-      proposal,
-      sim,
-      depsWithConfig,
-      l2Simulations,
-    ),
-  };
-  results.checkTouchedContractsNoSelfdestruct = {
-    name: ALL_CHECKS.checkTouchedContractsNoSelfdestruct.name,
-    result: await ALL_CHECKS.checkTouchedContractsNoSelfdestruct.checkProposal(
-      proposal,
-      sim,
-      depsWithConfig,
-      l2Simulations,
-    ),
-  };
-  results.checkSolc = {
-    name: ALL_CHECKS.checkSolc.name,
-    result: await ALL_CHECKS.checkSolc.checkProposal(proposal, sim, depsWithConfig, l2Simulations),
-  };
-  results.checkSlither = {
-    name: ALL_CHECKS.checkSlither.name,
-    result: await ALL_CHECKS.checkSlither.checkProposal(
-      proposal,
-      sim,
-      depsWithConfig,
-      l2Simulations,
-    ),
-  };
-
+  const { results } = await runChecksForChainWithDiagnostics(
+    proposal,
+    sim,
+    deps,
+    chainId,
+    allL2Simulations,
+  );
   return results;
 }
 
@@ -387,35 +934,25 @@ async function main() {
   // Handle cross-chain messages
   const finalResult = await handleCrossChainSimulations(sourceResult);
 
+  const finalDeps = finalResult.deps || proposalData;
+
   // Run checks for source chain
-  const sourceChecks = await runChecksForChain(
+  const sourceRun = await runChecksForChainWithDiagnostics(
     finalResult.proposal,
     finalResult.sim,
-    proposalData,
+    finalDeps,
     1, // Mainnet chain ID
     finalResult.destinationSimulations,
   );
+  const sourceChecks = sourceRun.results;
 
   // Run checks for destination chains if any
-  const destinationChecks: Record<number, AllCheckResults> = {};
-  if (finalResult.destinationSimulations) {
-    for (const destSim of finalResult.destinationSimulations) {
-      if (destSim.sim) {
-        const l2Deps: ProposalData = {
-          ...proposalData,
-          publicClient: getClientForChain(destSim.chainId),
-          chainConfig: getChainConfig(destSim.chainId),
-        };
-        destinationChecks[destSim.chainId] = await runChecksForChain(
-          finalResult.proposal,
-          destSim.sim,
-          l2Deps,
-          destSim.chainId,
-          finalResult.destinationSimulations,
-        );
-      }
-    }
-  }
+  const { destinationChecks, executionDiagnostics: destinationExecutionDiagnostics } =
+    await processDestinationChecks(
+      finalResult.proposal,
+      finalDeps,
+      finalResult.destinationSimulations,
+    );
 
   // Fetch full block data for start and end blocks
   const [startBlock, endBlock] = await Promise.all([
@@ -438,21 +975,15 @@ async function main() {
   const coverageMetadata = buildCoverageMetadata();
   const coverage = buildCoverageFromResults(sourceChecks, coverageMetadata, 1);
 
-  // Merge L2 check coverage into the main coverage
-  for (const [chainIdStr, destResults] of Object.entries(destinationChecks)) {
-    const chainId = Number(chainIdStr);
-    const l2Coverage = buildCoverageFromResults(destResults, coverageMetadata, chainId);
-
-    // Append L2 checks to the main coverage
-    coverage.checks.push(...l2Coverage.checks);
-
-    // Aggregate summary totals
-    coverage.summary.total += l2Coverage.summary.total;
-    coverage.summary.ran += l2Coverage.summary.ran;
-    coverage.summary.skipped += l2Coverage.summary.skipped;
-    coverage.summary.failed += l2Coverage.summary.failed;
-    coverage.summary.inferredSkips += l2Coverage.summary.inferredSkips;
-  }
+  appendDestinationCoverageDiagnostics(
+    coverage,
+    destinationChecks,
+    finalResult.destinationSimulations,
+    {
+      1: sourceRun.diagnostics,
+      ...destinationExecutionDiagnostics,
+    },
+  );
 
   // Log coverage summary
   console.log(
@@ -478,7 +1009,7 @@ async function main() {
     executor: finalResult.executor,
     proposalCreatedBlock: finalResult.proposalCreatedBlock,
     proposalExecutedBlock: finalResult.proposalExecutedBlock,
-    chainId: proposalData.chainConfig.chainId,
+    chainId: finalDeps.chainConfig.chainId,
     simulationType: simType,
     simulation: finalResult.sim,
     coverage,

--- a/tests/issue-198-resilience.test.ts
+++ b/tests/issue-198-resilience.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeSimulationResultsJson } from '../presentation/report';
+import {
+  appendDestinationCoverageDiagnostics,
+  buildCoverageFromResults,
+  buildCoverageMetadata,
+  runChecksForChainWithDiagnostics,
+} from '../run-checks';
+import type {
+  AllCheckResults,
+  ChainExecutionDiagnostics,
+  ProposalCheck,
+  ProposalData,
+  ProposalEvent,
+  TenderlySimulation,
+} from '../types';
+import { getChainConfig } from '../utils/clients/client';
+
+const proposal: ProposalEvent = {
+  id: 198n,
+  proposalId: 198n,
+  proposer: '0x1234567890abcdef1234567890abcdef12345678',
+  startBlock: 1n,
+  endBlock: 2n,
+  description: '# Issue 198\n\nResilience test proposal.',
+  targets: ['0x1111111111111111111111111111111111111111'],
+  values: [0n],
+  signatures: ['transfer(address,uint256)'],
+  calldatas: ['0x'],
+};
+
+const sim = {} as TenderlySimulation;
+
+const deps: ProposalData = {
+  governor: {},
+  timelock: {},
+  publicClient: {},
+  chainConfig: getChainConfig(1),
+  targets: [],
+  touchedContracts: [],
+};
+
+describe('Issue #198 resilience behavior', () => {
+  it('isolates per-check execution and applies a single retry for transient failures', async () => {
+    let retrySuccessAttempts = 0;
+    let retryFailureAttempts = 0;
+
+    const checksOverride: Record<string, ProposalCheck> = {
+      checkStateChanges: {
+        name: 'Retry succeeds',
+        async checkProposal() {
+          retrySuccessAttempts += 1;
+          if (retrySuccessAttempts === 1) {
+            throw new Error('RPC request failed with ETIMEDOUT');
+          }
+          return { info: ['recovered'], warnings: [], errors: [] };
+        },
+      },
+      checkLogs: {
+        name: 'Retry fails',
+        async checkProposal() {
+          retryFailureAttempts += 1;
+          throw new Error('Sourcify network error 503');
+        },
+      },
+      checkProxyResolution: {
+        name: 'Still runs after failure',
+        async checkProposal() {
+          return { info: ['continued'], warnings: [], errors: [] };
+        },
+      },
+    };
+
+    const chainRun = await runChecksForChainWithDiagnostics(
+      proposal,
+      sim,
+      deps,
+      1,
+      undefined,
+      checksOverride,
+    );
+
+    expect(chainRun.results.checkStateChanges.result.info).toEqual(['recovered']);
+    expect(chainRun.results.checkLogs.result.skipped?.reason).toContain('Inconclusive');
+    expect(chainRun.results.checkProxyResolution.result.info).toEqual(['continued']);
+
+    expect(retrySuccessAttempts).toBe(2);
+    expect(retryFailureAttempts).toBe(2);
+
+    const retrySuccessDiagnostic = chainRun.diagnostics.retries.find(
+      (entry) => entry.checkId === 'checkStateChanges',
+    );
+    expect(retrySuccessDiagnostic?.outcome).toBe('success');
+    expect(retrySuccessDiagnostic?.retries).toBe(1);
+
+    const retryFailureDiagnostic = chainRun.diagnostics.retries.find(
+      (entry) => entry.checkId === 'checkLogs',
+    );
+    expect(retryFailureDiagnostic?.outcome).toBe('failed');
+    expect(retryFailureDiagnostic?.retries).toBe(1);
+
+    expect(chainRun.diagnostics.failedChecks.map((entry) => entry.checkId)).toContain('checkLogs');
+    expect(chainRun.diagnostics.partial).toBe(true);
+    expect(chainRun.diagnostics.partialReason).toContain('checkLogs');
+  });
+
+  it('marks destination chain as inconclusive/partial in structured JSON when checks are degraded', () => {
+    const sourceChecks: AllCheckResults = {
+      checkStateChanges: {
+        name: 'State Changes',
+        result: {
+          info: ['ok'],
+          warnings: [],
+          errors: [],
+        },
+      },
+    };
+
+    const coverage = buildCoverageFromResults(sourceChecks, buildCoverageMetadata(), 1);
+
+    const destinationDiagnostics: Record<number, ChainExecutionDiagnostics> = {
+      42161: {
+        chainId: 42161,
+        attemptedChecks: ['checkStateChanges', 'checkLogs'],
+        failedChecks: [
+          {
+            checkId: 'checkLogs',
+            checkName: 'Logs',
+            reason: 'Check execution failed (checkLogs): Sourcify network error 503',
+            retryable: true,
+            retries: 1,
+          },
+        ],
+        retries: [
+          {
+            checkId: 'checkLogs',
+            checkName: 'Logs',
+            retries: 1,
+            outcome: 'failed',
+            lastError: 'Sourcify network error 503',
+          },
+        ],
+        partial: true,
+        partialReason:
+          'Destination simulation succeeded but destination checks were partial: checkLogs failed.',
+      },
+    };
+
+    appendDestinationCoverageDiagnostics(
+      coverage,
+      {},
+      [
+        {
+          chainId: 42161,
+          bridgeType: 'ArbitrumL1L2',
+          status: 'success',
+        },
+      ],
+      {
+        1: {
+          chainId: 1,
+          attemptedChecks: ['checkStateChanges'],
+          failedChecks: [],
+          retries: [],
+          partial: false,
+        },
+        ...destinationDiagnostics,
+      },
+    );
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-issue-198-'));
+    const outputPath = join(outputDir, 'simulation-results.json');
+
+    const blocks = {
+      current: { number: 3n, timestamp: 3n },
+      start: { number: 1n, timestamp: 1n },
+      end: { number: 2n, timestamp: 2n },
+    };
+
+    writeSimulationResultsJson({
+      governorType: 'bravo',
+      blocks,
+      proposal,
+      checks: sourceChecks,
+      markdownReport: '# Report',
+      governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+      outputPath,
+      destinationSimulations: [
+        {
+          chainId: 42161,
+          bridgeType: 'ArbitrumL1L2',
+          status: 'success',
+        },
+      ],
+      destinationChecks: {},
+      chainId: 1,
+      simulationType: 'proposed',
+      coverage,
+    });
+
+    const parsed = JSON.parse(readFileSync(outputPath, 'utf8'));
+    const report = parsed.report.structuredReport;
+
+    expect(report.status).toBe('inconclusive');
+    expect(report.coverage.executionDiagnostics['42161'].partial).toBe(true);
+
+    const chainReport = report.chainReports.find(
+      (entry: { chainId: number }) => entry.chainId === 42161,
+    );
+    expect(chainReport).toBeDefined();
+    expect(chainReport.status).toBe('inconclusive');
+    expect(
+      chainReport.checks.some(
+        (entry: { checkId?: string; status: string }) =>
+          entry.checkId === 'destinationCheckExecution' && entry.status === 'inconclusive',
+      ),
+    ).toBe(true);
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -603,6 +603,31 @@ export interface CoverageMetadata {
   runnerOs?: string;
 }
 
+export interface CheckRetryDiagnostic {
+  checkId: string;
+  checkName: string;
+  retries: number;
+  outcome: 'success' | 'failed';
+  lastError: string;
+}
+
+export interface FailedCheckExecutionDiagnostic {
+  checkId: string;
+  checkName: string;
+  reason: string;
+  retryable: boolean;
+  retries: number;
+}
+
+export interface ChainExecutionDiagnostics {
+  chainId: number;
+  attemptedChecks: string[];
+  failedChecks: FailedCheckExecutionDiagnostic[];
+  retries: CheckRetryDiagnostic[];
+  partial: boolean;
+  partialReason?: string;
+}
+
 export interface CoverageData {
   metadata: CoverageMetadata;
   checks: CheckCoverage[];
@@ -613,6 +638,7 @@ export interface CoverageData {
     failed: number;
     inferredSkips: number;
   };
+  executionDiagnostics?: Record<number, ChainExecutionDiagnostics>;
 }
 
 /**
@@ -622,7 +648,7 @@ export interface SimulationCheck {
   checkId?: string;
   chainId?: number;
   title: string;
-  status: 'passed' | 'warning' | 'failed' | 'skipped';
+  status: 'passed' | 'warning' | 'failed' | 'skipped' | 'inconclusive';
   skipReason?: string;
   warningCount?: number;
   errorCount?: number;
@@ -712,7 +738,7 @@ export interface CrossChainPreview {
     chainId: number;
     chainName: string;
     blockExplorerBaseUrl?: string;
-    status: 'success' | 'warning' | 'error';
+    status: 'success' | 'warning' | 'error' | 'inconclusive';
     checks: SimulationCheck[];
   }>;
 }
@@ -765,7 +791,7 @@ export interface ChainSimulationReport {
   chainId: number;
   chainName: string;
   blockExplorerBaseUrl?: string;
-  status: 'success' | 'warning' | 'error';
+  status: 'success' | 'warning' | 'error' | 'inconclusive';
   checks: SimulationCheck[];
   stateChanges: SimulationStateChange[];
   events: SimulationEvent[];


### PR DESCRIPTION
## Summary
- add per-check isolation in `runChecksForChain` via a resilient execution boundary so one thrown check does not stop subsequent checks
- add bounded retry policy (max 1 retry) for transient/network-like failures and persist structured inconclusive results when retries are exhausted
- add per-chain execution diagnostics (attempted checks, failed checks, retries, partial reason) into structured report coverage JSON
- mark destination chains and overall report as **inconclusive** when destination simulation succeeds but destination checks are partial/degraded
- unify destination-check processing + coverage handling between `index.ts` and `run-checks.ts` to avoid divergent behavior on missing/partial destination checks
- preserve deterministic ordering and keep explicit `solc` before `slither`

## Before
- a thrown check in destination-chain execution could interrupt remaining checks for that chain
- transient RPC/explorer-like errors had no retry at check execution boundary
- destination simulation success with degraded check execution was not explicitly surfaced as partial/inconclusive in structured data
- `index.ts` and `run-checks.ts` could diverge in handling missing/unsupported destination-check scenarios

## After
- check execution is isolated per check; failures are captured as structured inconclusive check results with clear reasons
- one retry is attempted for retryable transient failures; retries are recorded in diagnostics
- structured report JSON includes per-chain execution diagnostics and explicit partial/inconclusive status signaling
- runner paths share the same destination check/coverage logic for consistent behavior

## Validation
- `bun run check`
- `MAINNET_RPC_URL=http://localhost:8545 ARBITRUM_RPC_URL=http://localhost:8545 ETHERSCAN_API_KEY=test TENDERLY_ACCESS_TOKEN=test TENDERLY_USER=test TENDERLY_PROJECT_SLUG=test bun test tests/check-runner-timeouts.test.ts tests/issue-198-resilience.test.ts`
- induced proposal/report generation path in `tests/issue-198-resilience.test.ts` verifies structured output includes partial/inconclusive destination diagnostics

## Tradeoffs
- transient retry classification is heuristic (message/code pattern based), so some non-transient failures may still consume one retry attempt
- structured report now adds inconclusive diagnostic entries for partial destination chains, which increases JSON verbosity but makes degraded execution explicit and machine-readable

Fixes #198