### PR TITLE
chore: automate Seatbelt viewer Vercel deploy

### DIFF
--- a/.github/workflows/deploy-seatbelt-viewer.yml
+++ b/.github/workflows/deploy-seatbelt-viewer.yml
@@ -1,0 +1,67 @@
+name: Deploy Seatbelt viewer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-seatbelt-viewer.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-seatbelt-viewer-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy frontend to Vercel production
+    runs-on: ubuntu-24.04
+
+    # Required repository secret:
+    # - VERCEL_TOKEN: Vercel token with access to project "seatbelt-viewer"
+    #   in scope "marcos-projects-5a62a7ed"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: 20
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Ensure VERCEL_TOKEN is configured
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "Missing required secret: VERCEL_TOKEN"
+            exit 1
+          fi
+
+      - name: Link Vercel project (non-interactive)
+        working-directory: frontend
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel link \
+            --yes \
+            --project seatbelt-viewer \
+            --scope marcos-projects-5a62a7ed \
+            --token "$VERCEL_TOKEN"
+
+      - name: Deploy to production
+        working-directory: frontend
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel deploy \
+            --prod \
+            --yes \
+            --scope marcos-projects-5a62a7ed \
+            --token "$VERCEL_TOKEN"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,6 +53,22 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Production deploys for the viewer are automated by GitHub Actions via
+`.github/workflows/deploy-seatbelt-viewer.yml`.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+### CI deploy trigger
+
+The workflow deploys to production when:
+
+- a commit is pushed to `main`, and
+- the change touches `frontend/**` (or the workflow file itself)
+
+A manual deploy can also be started with **Actions → Deploy Seatbelt viewer → Run workflow**.
+
+### Required GitHub secret
+
+Configure this repository secret before enabling CI deploys:
+
+- `VERCEL_TOKEN`: Vercel token with access to project `seatbelt-viewer` in scope `marcos-projects-5a62a7ed`
+
+The workflow links the project non-interactively and runs `vercel deploy --prod`.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the Seatbelt viewer to Vercel production
- trigger on pushes to `main` that touch `frontend/**` (plus manual `workflow_dispatch`)
- add a concurrency guard to prevent overlapping production deploys
- document required secret/setup in `frontend/README.md`

## Setup notes
- configure repository secret: `VERCEL_TOKEN`
- token must be able to deploy project `seatbelt-viewer` in scope `marcos-projects-5a62a7ed`

## Validation
- validated workflow YAML: `npx --yes yaml@2.8.1 valid < .github/workflows/deploy-seatbelt-viewer.yml`
- trigger paths exclude docs-only changes
