### PR TITLE
fix: restore known chain names in overview

### DIFF
--- a/frontend/src/components/structured-report/chain-name.ts
+++ b/frontend/src/components/structured-report/chain-name.ts
@@ -1,3 +1,33 @@
+import {
+  arbitrum,
+  base,
+  bob,
+  celo,
+  ink,
+  mainnet,
+  optimism,
+  soneium,
+  unichain,
+  worldchain,
+  xLayer,
+  zora,
+} from 'viem/chains';
+
+const KNOWN_CHAIN_NAMES: Record<number, string> = {
+  [mainnet.id]: mainnet.name,
+  [optimism.id]: optimism.name,
+  [base.id]: base.name,
+  [arbitrum.id]: arbitrum.name,
+  [unichain.id]: unichain.name,
+  [ink.id]: ink.name,
+  [soneium.id]: soneium.name,
+  [bob.id]: bob.name,
+  [celo.id]: celo.name,
+  [worldchain.id]: worldchain.name,
+  [xLayer.id]: xLayer.name,
+  [zora.id]: zora.name,
+};
+
 const GENERIC_CHAIN_NAME = /^Chain\s+\d+$/i;
 
 export function resolveChainName(chainId: number, providedName?: string): string {
@@ -6,5 +36,5 @@ export function resolveChainName(chainId: number, providedName?: string): string
     return cleanedProvidedName;
   }
 
-  return `Chain ${chainId}`;
+  return KNOWN_CHAIN_NAMES[chainId] ?? `Chain ${chainId}`;
 }

--- a/tests/frontend-chain-name.test.ts
+++ b/tests/frontend-chain-name.test.ts
@@ -6,11 +6,17 @@ describe('frontend resolveChainName', () => {
     expect(resolveChainName(42161, 'Arbitrum One')).toBe('Arbitrum One');
   });
 
-  test('falls back to generic chain label when provided name is generic', () => {
-    expect(resolveChainName(42161, 'Chain 42161')).toBe('Chain 42161');
+  test('uses known chain names when provided name is generic', () => {
+    expect(resolveChainName(42220, 'Chain 42220')).toBe('Celo');
+    expect(resolveChainName(7777777, 'Chain 7777777')).toBe('Zora');
   });
 
-  test('falls back to generic chain label when name is missing', () => {
-    expect(resolveChainName(8453)).toBe('Chain 8453');
+  test('uses known chain names when name is missing', () => {
+    expect(resolveChainName(8453)).toBe('Base');
+  });
+
+  test('falls back to generic chain label for unknown chain ids', () => {
+    expect(resolveChainName(999999999, 'Chain 999999999')).toBe('Chain 999999999');
+    expect(resolveChainName(999999999)).toBe('Chain 999999999');
   });
 });


### PR DESCRIPTION
## Summary
Fixes a regression where known chains in the viewer Overview section (especially Check Coverage / cross-chain summary paths) could render as generic labels like `Chain 42220` and `Chain 7777777`.

## Root cause
In `feat/issue-177-chain-capability-registry`, `frontend/src/components/structured-report/chain-name.ts` removed the local known-chain mapping and only returned:
- provided name if non-generic, otherwise
- `Chain {id}`

That meant when Overview paths had missing/generic names (common in coverage/no-check paths), frontend resolution could no longer recover canonical names for known chain IDs.

## Fix
Minimal frontend-only fix in `resolveChainName`:
1. Keep preferring provided non-generic names.
2. Add known chain-name fallback using `viem/chains` IDs/names (same chain set used by Seatbelt capabilities: mainnet, optimism, base, arbitrum, unichain, ink, soneium, bob, celo, worldchain, xLayer, zora).
3. Keep generic fallback only for unknown IDs.

## Tests
Updated `tests/frontend-chain-name.test.ts` to cover the regression and fallback behavior:
- generic provided name for known IDs resolves to canonical names (`42220 -> Celo`, `7777777 -> Zora`)
- missing name for known ID resolves to canonical name (`8453 -> Base`)
- unknown IDs still resolve to `Chain {id}`

## Validation
- `bun run check`
- `cd frontend && bun run check`
- `bun test tests/frontend-chain-name.test.ts tests/proposal-summary.test.ts`

All pass locally.

## Why this won’t regress
The targeted tests now assert the exact known-chain fallback behavior that regressed. Any future change that drops known-name resolution (or reverts to generic labels for known IDs) will fail CI in this test suite.