### PR TITLE
fix: stop rate limiting publish lookups

### DIFF
--- a/relay/server.ts
+++ b/relay/server.ts
@@ -1259,8 +1259,7 @@ export function createRelayFetchHandler(
     }
 
     const shouldRateLimitPublishEndpoint =
-      (request.method === 'POST' && pathname === '/api/v1/publishes') ||
-      (request.method === 'GET' && pathname.startsWith('/api/v1/publishes/'));
+      request.method === 'POST' && pathname === '/api/v1/publishes';
 
     if (shouldRateLimitPublishEndpoint) {
       const now = nowMs();

--- a/tests/publish-relay.test.ts
+++ b/tests/publish-relay.test.ts
@@ -388,7 +388,7 @@ describe('managed publish relay endpoints', () => {
     expect(publishCallCount).toBe(1);
   });
 
-  it('enforces rate limit on publish lookup endpoint', async () => {
+  it('does not rate limit publish lookup endpoint', async () => {
     const handler = createRelayFetchHandler({
       config: {
         rateLimitEnabled: true,
@@ -423,8 +423,8 @@ describe('managed publish relay endpoints', () => {
     );
 
     expect(firstResponse.status).toBe(404);
-    expect(secondResponse.status).toBe(429);
-    expect(secondResponse.headers.get('retry-after')).not.toBeNull();
+    expect(secondResponse.status).toBe(404);
+    expect(secondResponse.headers.get('retry-after')).toBeNull();
   });
 
   it('deduplicates duplicate idempotency keys in a single relay instance', async () => {


### PR DESCRIPTION
## Summary
- stop relay rate limiting from applying to publish lookup reads
- keep rate limiting on publish writes to `/api/v1/publishes`
- restore `/p/<publishId>` resolution so lookup requests do not fail with relay-generated `429`s

## Changes
- narrow the relay rate-limit predicate to `POST /api/v1/publishes` only
- update relay coverage to verify repeated publish lookups are not rate limited
- keep existing POST rate-limit coverage in place

## Test Plan
- `bun test tests/publish-relay.test.ts`
- `bun run typecheck`

Resolves #219
