### PR TITLE
fix: hide cross-chain step counts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,7 @@ Consumers should treat these outputs as a **pipeline** with four gates. If a gat
      - If `coverage.summary.skipped > 0`, treat as incomplete.
      - If `coverage.summary.inferredSkips > 0`, treat as incomplete (heuristic skips indicate partial execution).
    - If `report.structuredReport.crossChain` exists:
-     - If any `crossChain.messages[].status === "failure"`, treat as incomplete (destination simulation did not complete).
+     - If any `crossChain.jobs[].status === "failure"`, treat as incomplete (destination simulation did not complete).
 
 4) **Gate 4 — Decision**
    - Use `report.structuredReport.status` as the canonical decision bucket:
@@ -196,42 +196,38 @@ export interface CheckCoverage {
 
 ### `CrossChainPreview` (destination simulation preview)
 
-This is a lightweight, UI-friendly summary of extracted L2 messages. It is **optional** and may be absent.
-If `destinationChains` is present, it includes the full per-chain check findings for destination simulations.
+This is a lightweight, UI-friendly summary of destination-chain actions. It is **optional** and may be absent.
+Each `job` is one cross-chain action on a destination chain. Its `steps` are the ordered low-level calls used to carry that action out.
 
 ```ts
 export interface CrossChainPreview {
-  messages: CrossChainMessagePreview[];
-  destinationChains?: Array<{
-    chainId: number;
-    chainName: string;
-    blockExplorerBaseUrl?: string;
-    status: 'success' | 'warning' | 'error';
-    checks: SimulationCheck[];
-  }>;
+  jobs: CrossChainJobPreview[];
 }
 
-export interface CrossChainMessagePreview {
+export interface CrossChainJobPreview {
   chainId: number;
   chainName: string;
   blockExplorerBaseUrl: string;
   bridgeType: string;                    // e.g. "ArbitrumL1L2" | "OptimismL1L2"
+  status: 'success' | 'failure' | 'skipped';
+  error?: string;
+  l2FromAddress: `0x${string}`;
+  sourceOrder: number;
+  steps: CrossChainJobStepPreview[];
+}
+
+export interface CrossChainJobStepPreview {
+  stepIndex: number;
   status: 'success' | 'failure';
   error?: string;
-
-  l2FromAddress?: `0x${string}`;
-  l2TargetAddress?: `0x${string}`;
-  l2Value?: string;                      // decimal string
-  l2InputData?: `0x${string}`;           // calldata
-
-  // Optional label inferred from the destination simulation contract list.
-  targetLabel?: string;
-
-  // Optional decode (best-effort).
+  l2TargetAddress: `0x${string}`;
+  l2Value: string;                       // decimal string
+  l2InputData: `0x${string}`;            // calldata
+  targetLabel?: string;                  // inferred from destination contracts
   call?: {
     selector: `0x${string}`;
     signature?: string;                  // e.g. "transfer(address,uint256)"
-    args?: unknown[];                    // optional; present when full decoding is available
+    args?: unknown[];
   };
 }
 ```

--- a/frontend/src/components/CallGroupedView.test.tsx
+++ b/frontend/src/components/CallGroupedView.test.tsx
@@ -66,7 +66,7 @@ function makeReport(jobs: CrossChainJobPreview[]): StructuredSimulationReport {
 }
 
 describe('CallGroupedView cross-chain summary headers', () => {
-  it('removes step-count copy but keeps multi-job labels and technical step details', () => {
+  it('omits aggregate action labels while keeping technical step details', () => {
     const html = renderToStaticMarkup(
       createElement(CallGroupedView, {
         proposal,
@@ -77,8 +77,11 @@ describe('CallGroupedView cross-chain summary headers', () => {
       }),
     );
 
-    expect(html).toContain('Execution 1');
-    expect(html).toContain('Execution 2');
+    expect(html).not.toContain('2 actions');
+    expect(html).not.toContain('Action 1');
+    expect(html).not.toContain('Action 2');
+    expect(html).not.toContain('Execution 1');
+    expect(html).not.toContain('Execution 2');
     expect(html).toContain('bridgeFirst');
     expect(html).toContain('bridgeSecond');
     expect(html).toContain('cleanup');

--- a/frontend/src/components/CallGroupedView.tsx
+++ b/frontend/src/components/CallGroupedView.tsx
@@ -970,7 +970,6 @@ function CrossChainCallsSection({
                 )}
               </div>
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                {chainJobs.length > 1 ? <span>{chainJobs.length} executions</span> : null}
                 {failedCount > 0 && (
                   <Badge variant="destructive" className="text-[10px] px-1.5">
                     {failedCount} failed
@@ -979,11 +978,10 @@ function CrossChainCallsSection({
               </div>
             </div>
 
-            {chainJobs.map((job, jobIndex) => {
+            {chainJobs.map((job) => {
               const firstStep = job.steps[0];
               const target = firstStep?.l2TargetAddress;
               const targetLabel = firstStep?.targetLabel;
-              const executionLabel = chainJobs.length > 1 ? `Execution ${jobIndex + 1}` : null;
 
               return (
                 <div
@@ -1008,11 +1006,6 @@ function CrossChainCallsSection({
                           {targetLabel}
                         </Badge>
                       )}
-                      {executionLabel ? (
-                        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                          {executionLabel}
-                        </Badge>
-                      ) : null}
                       {job.status === 'skipped' && (
                         <Badge variant="outline" className="text-[10px] px-1.5 py-0">
                           Skipped

--- a/frontend/src/components/StructuredReport.tsx
+++ b/frontend/src/components/StructuredReport.tsx
@@ -184,7 +184,7 @@ export function StructuredReport({ report, proposal }: StructuredReportProps) {
               {report.crossChain?.jobs?.length ? (
                 <section className="rounded-lg border-2 border-border bg-card p-4 sm:p-5">
                   <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-                    Cross-Chain Executions
+                    Cross-Chain
                   </h3>
                   <CrossChainPreview jobs={report.crossChain.jobs} />
                 </section>

--- a/frontend/src/components/structured-report/CrossChainChecksSummary.test.tsx
+++ b/frontend/src/components/structured-report/CrossChainChecksSummary.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import type { CrossChainJobPreview } from '@/hooks/use-simulation-results';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CrossChainChecksSummary } from './CrossChainChecksSummary';
+
+function makeJob(overrides: Partial<CrossChainJobPreview> = {}): CrossChainJobPreview {
+  return {
+    chainId: 42161,
+    chainName: 'Arbitrum',
+    blockExplorerBaseUrl: 'https://arbiscan.io',
+    bridgeType: 'ArbitrumL1L2',
+    status: 'failure',
+    error: 'bridge reverted',
+    l2FromAddress: '0x1111111111111111111111111111111111111111',
+    sourceOrder: 0,
+    steps: [
+      {
+        stepIndex: 0,
+        status: 'failure',
+        error: 'bridge reverted',
+        l2TargetAddress: '0x2222222222222222222222222222222222222222',
+        l2Value: '0',
+        l2InputData: '0x12345678',
+        targetLabel: 'Arbitrum target',
+        call: {
+          selector: '0x12345678',
+          signature: 'bridgeAction()',
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('CrossChainChecksSummary', () => {
+  it('lists failed jobs without action or execution ordinals', () => {
+    const html = renderToStaticMarkup(
+      createElement(CrossChainChecksSummary, {
+        jobs: [makeJob(), makeJob({ sourceOrder: 1 })],
+      }),
+    );
+
+    expect(html).toContain('Cross-chain results');
+    expect(html).toContain('failed:');
+    expect(html).not.toContain('Action 1');
+    expect(html).not.toContain('Action 2');
+    expect(html).not.toContain('Execution 1');
+    expect(html).not.toContain('Execution 2');
+  });
+});

--- a/frontend/src/components/structured-report/CrossChainChecksSummary.tsx
+++ b/frontend/src/components/structured-report/CrossChainChecksSummary.tsx
@@ -27,7 +27,7 @@ export function CrossChainChecksSummary({ jobs, onNavigateToChain }: CrossChainC
             <CheckCircleIcon className="h-5 w-5 text-green-500 mt-0.5" />
           )}
           <div>
-            <div className="font-semibold">Cross-chain jobs</div>
+            <div className="font-semibold">Cross-chain results</div>
             <div className="text-xs text-muted-foreground">
               L2 execution can fail independently of the main-chain checks.
             </div>
@@ -113,7 +113,6 @@ export function CrossChainChecksSummary({ jobs, onNavigateToChain }: CrossChainC
                     className="flex items-center gap-2 flex-wrap"
                   >
                     <span className="text-red-600 font-medium">
-                      {chain.total > 1 ? `Execution ${job.executionIndex + 1} ` : ''}
                       {job.status === 'skipped' ? 'skipped' : 'failed'}:
                     </span>
                     {job.call ? (

--- a/frontend/src/components/structured-report/CrossChainPreview.test.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.test.tsx
@@ -43,7 +43,9 @@ describe('CrossChainPreview', () => {
     expect(html).toContain('Arbitrum');
     expect(html).toContain('Arbitrum target');
     expect(html).toContain('bridgeAction1()');
-    expect(html).toContain('Execution 2');
+    expect(html).not.toContain('Action 1');
+    expect(html).not.toContain('Action 2');
+    expect(html).not.toContain('Execution 2');
     expect(html).not.toContain('1 step');
     expect(html).not.toContain('2 steps');
   });

--- a/frontend/src/components/structured-report/CrossChainPreview.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.tsx
@@ -46,13 +46,12 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
             </div>
 
             <div className="space-y-2">
-              {chainJobs.map((job, jobIndex) => {
+              {chainJobs.map((job) => {
                 const firstStep = job.steps[0];
                 const jobKey = `${job.chainId}-${job.bridgeType}-${job.sourceOrder}-${job.l2FromAddress}-${job.status}`;
                 const target = firstStep?.l2TargetAddress;
                 const targetLabel = firstStep?.targetLabel;
                 const call = firstStep ? formatCrossChainCall(firstStep) : '(empty job)';
-                const executionLabel = chainJobs.length > 1 ? `Execution ${jobIndex + 1}` : null;
 
                 const statusBadge =
                   job.status === 'success' ? (
@@ -73,9 +72,6 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
                   <div key={jobKey} className="border border-border/40 rounded bg-muted/20 p-2.5">
                     <div className="flex items-center justify-between gap-2">
                       <div className="flex items-center gap-2 text-xs">
-                        {executionLabel ? (
-                          <span className="text-muted-foreground">{executionLabel}</span>
-                        ) : null}
                         {targetLabel ? <span className="font-medium">{targetLabel}</span> : null}
                         {target ? (
                           <a

--- a/frontend/src/components/structured-report/cross-chain.ts
+++ b/frontend/src/components/structured-report/cross-chain.ts
@@ -20,7 +20,6 @@ type CrossChainChainSummary = {
   successCount: number;
   failureCount: number;
   failures: Array<{
-    executionIndex: number;
     sourceOrder: number;
     status: 'failure' | 'skipped';
     call: string | null;
@@ -64,8 +63,7 @@ export function summarizeCrossChainJobs(jobs: CrossChainJobPreview[]): {
         successCount,
         failureCount,
         failures: chainJobs
-          .map((job, executionIndex) => ({
-            executionIndex,
+          .map((job) => ({
             sourceOrder: job.sourceOrder,
             call: job.steps[0] ? formatCrossChainCall(job.steps[0]) : null,
             targetLabel: job.steps[0]?.targetLabel,
@@ -74,8 +72,7 @@ export function summarizeCrossChainJobs(jobs: CrossChainJobPreview[]): {
             error: job.error,
           }))
           .filter((job) => job.status !== 'success')
-          .map(({ executionIndex, sourceOrder, status, call, targetLabel, target, error }) => ({
-            executionIndex,
+          .map(({ sourceOrder, status, call, targetLabel, target, error }) => ({
             sourceOrder,
             status: toFailureStatus(status),
             call,


### PR DESCRIPTION
## Summary
- remove per-job step-count copy from cross-chain summary headers
- keep the UI focused on destination chain, action, and status
- preserve step sequencing only in expanded technical detail rows

## Changes
- delete the `N step(s)` summary text from `CrossChainPreview`
- delete the per-job `N step(s)` header text from `CallGroupedView`
- add focused SSR component coverage for both surfaces

## Test Plan
- `cd frontend && bun run check`
- `cd frontend && bun test src/components/structured-report/CrossChainPreview.test.tsx src/components/CallGroupedView.test.tsx`

Resolves #225