### PR TITLE
fix: clean verification check rendering

### DIFF
--- a/frontend/src/components/structured-report/ContractVerificationList.test.tsx
+++ b/frontend/src/components/structured-report/ContractVerificationList.test.tsx
@@ -18,6 +18,22 @@ describe('ContractVerificationList link routing', () => {
     expect(html).not.toContain(`href="https://etherscan.io/address/${address}"`);
   });
 
+  it('parses backticked markdown links for explorer-routed rows', () => {
+    const address = '0x3333333333333333333333333333333333333333';
+    const details = `[\`${address}\`](https://celoscan.io/address/${address}): EOA (may have code later, verification not applicable)`;
+
+    const html = renderToStaticMarkup(
+      createElement(ContractVerificationList, {
+        details,
+        blockExplorerBaseUrl: 'https://celoscan.io',
+      }),
+    );
+
+    expect(html).toContain(`href="https://celoscan.io/address/${address}"`);
+    expect(html).toContain('EOA');
+    expect(html).not.toContain('https://etherscan.io/address/');
+  });
+
   it('uses chain explorer links from check details for non-mainnet chains', () => {
     const address = '0x2222222222222222222222222222222222222222';
     const details = `[${address}](https://soneium.blockscout.com/address/${address}): Contract (verified via verification backend API)`;

--- a/frontend/src/components/structured-report/ContractVerificationList.tsx
+++ b/frontend/src/components/structured-report/ContractVerificationList.tsx
@@ -9,6 +9,7 @@ import {
   UserIcon,
 } from 'lucide-react';
 import { useMemo } from 'react';
+import { ADDRESS_MARKDOWN_LINK_REGEX } from './addressMarkdownLink';
 
 type VerificationStatus = 'verified' | 'unverified' | 'eoa' | 'unknown';
 
@@ -30,7 +31,7 @@ function normalizeBaseUrl(baseUrl?: string): string {
 }
 
 function parseVerificationLine(line: string): ParsedContractBase | null {
-  const markdownLinkMatch = line.match(/\[`?(0x[a-fA-F0-9]{40})`?\]\((https?:\/\/[^)]+)\)/);
+  const markdownLinkMatch = line.match(ADDRESS_MARKDOWN_LINK_REGEX);
   const plainAddressMatch = line.match(/(0x[a-fA-F0-9]{40})/);
   const address = markdownLinkMatch?.[1] || plainAddressMatch?.[1];
 

--- a/frontend/src/components/structured-report/ExpandableCheckItem.test.tsx
+++ b/frontend/src/components/structured-report/ExpandableCheckItem.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ExpandableCheckItem } from './ExpandableCheckItem';
+
+describe('ExpandableCheckItem secondary line formatting', () => {
+  it('hides collapsed verification subtext while keeping the inferred badge', () => {
+    const address = '0x1000000000000000000000000000000000009450';
+    const secondAddress = '0x1000000000000000000000000000000000009451';
+    const html = renderToStaticMarkup(
+      createElement(ExpandableCheckItem, {
+        check: {
+          checkId: 'checkTargetsVerifiedOnBlockExplorer',
+          title: 'Check all targets are verified on Sourcify or block explorer',
+          status: 'passed',
+          details: [
+            `[\`${address}\`](https://celoscan.io/address/${address}): EOA (may have code later, verification not applicable)`,
+            `[\`${secondAddress}\`](https://celoscan.io/address/${secondAddress}): EOA (verification not applicable)`,
+          ].join('\n'),
+        },
+        coverage: {
+          checkId: 'checkTargetsVerifiedOnBlockExplorer',
+          checkName: 'Check all targets are verified on Sourcify or block explorer',
+          status: 'skipped',
+          skipReason: `[\`${address}\`](https://celoscan.io/address/${address}): EOA (may have code later, verification not applicable)`,
+          wasInferred: true,
+          chainId: 42220,
+        },
+      }),
+    );
+
+    expect(html).toContain('Inferred');
+    expect(html).not.toContain('2 EOA / other addresses');
+    expect(html).not.toContain(`[\`${address}\`](https://celoscan.io/address/${address})`);
+    expect(html).not.toContain(
+      `${address}: EOA (may have code later, verification not applicable)`,
+    );
+  });
+});

--- a/frontend/src/components/structured-report/ExpandableCheckItem.tsx
+++ b/frontend/src/components/structured-report/ExpandableCheckItem.tsx
@@ -32,6 +32,10 @@ import { FormattedCheckDetails } from './FormattedCheckDetails';
 import { ProxyResolutionDetails } from './ProxyResolutionDetails';
 import { StateChanges } from './StateChanges';
 
+function stripMarkdownLinks(text: string): string {
+  return text.replace(/\[`?([^`\]]+)`?\]\((https?:\/\/[^)]+)\)/g, '$1');
+}
+
 export function ExpandableCheckItem({
   check,
   stateChanges,
@@ -159,13 +163,14 @@ export function ExpandableCheckItem({
 
   const outcome = getOutcome(check, coverage);
   const methodTag = coverage?.wasInferred ? 'Inferred' : null;
-  const secondaryLine =
-    outcome === 'not_applicable'
-      ? (coverage?.skipReason ?? check.skipReason ?? 'Not applicable')
+  const secondaryLine = isVerificationCheck
+    ? null
+    : outcome === 'not_applicable'
+      ? stripMarkdownLinks(coverage?.skipReason ?? check.skipReason ?? 'Not applicable')
       : outcome === 'not_run'
-        ? (coverage?.skipReason ?? 'Not run')
+        ? stripMarkdownLinks(coverage?.skipReason ?? 'Not run')
         : coverage?.wasInferred && coverage?.skipReason
-          ? `Inferred: ${coverage.skipReason}`
+          ? `Inferred: ${stripMarkdownLinks(coverage.skipReason)}`
           : null;
 
   const treasuryData = useMemo(() => {

--- a/frontend/src/components/structured-report/FormattedCheckDetails.test.ts
+++ b/frontend/src/components/structured-report/FormattedCheckDetails.test.ts
@@ -65,4 +65,31 @@ describe('FormattedCheckDetails target row rendering', () => {
     expect(countOccurrences(html, 'Contract (with DELEGATECALL)')).toBe(1);
     expect(html).not.toContain('advisory for trusted bridge/proxy surface');
   });
+
+  it('renders backticked verification links as target rows instead of raw markdown', () => {
+    const address = '0x1000000000000000000000000000000000009450';
+    const details = `- [\`${address}\`](https://celoscan.io/address/${address}): EOA (may have code later, verification not applicable)`;
+
+    const html = renderToStaticMarkup(
+      createElement(FormattedCheckDetails, {
+        check: {
+          title: 'Check all targets are verified on Sourcify or block explorer',
+          status: 'warning',
+          details,
+        },
+        metadata: {
+          proposalId: '123',
+          proposer: '0x0000000000000000000000000000000000000001',
+          blockExplorerBaseUrl: 'https://celoscan.io',
+        },
+      }),
+    );
+
+    expect(html).toContain(address);
+    expect(
+      countOccurrences(html, 'flex items-center justify-between gap-2 p-2 bg-muted/30 rounded-md'),
+    ).toBe(1);
+    expect(html).toContain('EOA (may have code later)');
+    expect(html).not.toContain(`[\`${address}\`](https://celoscan.io/address/${address})`);
+  });
 });

--- a/frontend/src/components/structured-report/FormattedCheckDetails.tsx
+++ b/frontend/src/components/structured-report/FormattedCheckDetails.tsx
@@ -13,6 +13,7 @@ import { EventsDisplay } from './EventsDisplay';
 import { SecurityAnalysisOutput } from './SecurityAnalysisOutput';
 import { SimulationPlaceholderBadge } from './SimulationPlaceholderBadge';
 import { StateChanges } from './StateChanges';
+import { ADDRESS_MARKDOWN_LINK_REGEX } from './addressMarkdownLink';
 import { buildAddressLink, isPlaceholderAddress } from './explorer';
 
 export function FormattedCheckDetails({
@@ -144,14 +145,12 @@ export function FormattedCheckDetails({
             processedLine.includes('Contract (with DELEGATECALL') ||
             processedLine.includes('Contract (with SELFDESTRUCT)') ||
             processedLine.includes('Empty account (could deploy code later)') ||
-            processedLine.includes('EOA (may have code later)') ||
+            processedLine.includes('EOA (may have code later') ||
             processedLine.includes(': EOA') ||
             processedLine.includes('Trusted contract (not checked)');
 
           if (isTargetLine) {
-            const markdownLinkMatch = processedLine.match(
-              /\[(0x[a-fA-F0-9]{40})\]\(https?:\/\/[^)]+\)/,
-            );
+            const markdownLinkMatch = processedLine.match(ADDRESS_MARKDOWN_LINK_REGEX);
             const backtickMatch =
               processedLine.match(/\[`(0x[a-fA-F0-9]{40})`\]/) ||
               processedLine.match(/at `(0x[a-fA-F0-9]{40})`/);
@@ -172,7 +171,7 @@ export function FormattedCheckDetails({
                 status = 'Contract (with SELFDESTRUCT)';
               else if (processedLine.includes('Empty account (could deploy code later)'))
                 status = 'Empty account (could deploy code later)';
-              else if (processedLine.includes('EOA (may have code later)'))
+              else if (processedLine.includes('EOA (may have code later'))
                 status = 'EOA (may have code later)';
               else if (processedLine.includes(': EOA')) status = 'EOA';
 
@@ -393,7 +392,7 @@ export function FormattedCheckDetails({
           }
 
           const combinedRegex =
-            /\[(0x[a-fA-F0-9]{40})\]\(https?:\/\/[^)]+\)|`(0x[a-fA-F0-9]{40})`/g;
+            /\[`?(0x[a-fA-F0-9]{40})`?\]\(https?:\/\/[^)]+\)|`(0x[a-fA-F0-9]{40})`/g;
           let combinedMatch: RegExpExecArray | null;
 
           combinedMatch = combinedRegex.exec(processedLine);

--- a/frontend/src/components/structured-report/addressMarkdownLink.ts
+++ b/frontend/src/components/structured-report/addressMarkdownLink.ts
@@ -1,0 +1,1 @@
+export const ADDRESS_MARKDOWN_LINK_REGEX = /\[`?(0x[a-fA-F0-9]{40})`?\]\((https?:\/\/[^)]+)\)/;


### PR DESCRIPTION
## Summary
- Fix structured report verification checks so backticked markdown links render correctly
- Remove collapsed verification subtext so inferred checks match the rest of the checks list
- Add focused regressions for verification rows and collapsed check rendering

## Changes
- Reuse the optional-backtick markdown-link regex in the structured report viewers
- Keep expanded verification details rendering as linked target rows with badges
- Hide verification-specific secondary text in collapsed check items

## Test Plan
- bun test src/components/structured-report/FormattedCheckDetails.test.ts src/components/structured-report/ContractVerificationList.test.tsx src/components/structured-report/ExpandableCheckItem.test.tsx
- bunx @biomejs/biome check frontend/src/components/structured-report/FormattedCheckDetails.tsx frontend/src/components/structured-report/ContractVerificationList.tsx frontend/src/components/structured-report/ExpandableCheckItem.tsx frontend/src/components/structured-report/FormattedCheckDetails.test.ts frontend/src/components/structured-report/ContractVerificationList.test.tsx frontend/src/components/structured-report/ExpandableCheckItem.test.tsx frontend/src/components/structured-report/addressMarkdownLink.ts
- Verified locally at http://localhost:3000/p/d17ce867-6185-43b4-bdd4-76efdb5da9a3

Resolves #214