### PR TITLE
fix: preserve unichain sender in forwarded sims

### DIFF
--- a/checks/tests/cross-chain-bridge-parsing.test.ts
+++ b/checks/tests/cross-chain-bridge-parsing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { encodeFunctionData, parseAbi } from 'viem';
-import { arbitrum, base, optimism } from 'viem/chains';
+import { arbitrum, base, optimism, unichain } from 'viem/chains';
 import type { CallTrace, CrossChainExecutionJob } from '../../types';
 import {
   extractArbitrumL1L2Jobs,
@@ -403,6 +403,41 @@ describe('Cross-Chain Bridge Parsing Integration Tests', () => {
         bridgeType: 'OptimismL1L2',
         destinationChainId: 480,
       });
+    });
+
+    test('extractOptimismL1L2JobsFromProposal preserves the original sender for Unichain forwarded calls', () => {
+      const timelock = '0x1a9C8182C09F50C8318d769245beA52c32BE35BC';
+      const unichainMessenger = '0x9A3D64E386C18Cb1d6d5179a9596A4B5736e98A6';
+      const router = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D';
+      const finalTarget = '0x4200000000000000000000000000000000000006';
+      const finalData = '0xd0e30db0';
+      const forwardData = encodeFunctionData({
+        abi: parseAbi(['function forward(address target, bytes data)']),
+        functionName: 'forward',
+        args: [finalTarget, finalData],
+      });
+      const sendMessageCalldata = encodeFunctionData({
+        abi: parseAbi([
+          'function sendMessage(address _target, bytes _message, uint32 _minGasLimit)',
+        ]),
+        functionName: 'sendMessage',
+        args: [router, forwardData, 1_000_000],
+      });
+
+      const messages = extractOptimismL1L2JobsFromProposal(
+        [unichainMessenger],
+        [sendMessageCalldata],
+        timelock,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        bridgeType: 'OptimismL1L2',
+        destinationChainId: unichain.id,
+        l2FromAddress: timelock,
+      });
+      expect(firstCall(messages[0]).l2TargetAddress).toBe(finalTarget);
+      expect(firstCall(messages[0]).l2InputData).toBe(finalData);
     });
 
     test('extractOptimismL1L2JobsFromProposal parses portal depositTransaction targets', () => {

--- a/utils/bridges/optimism.ts
+++ b/utils/bridges/optimism.ts
@@ -8,6 +8,7 @@ import {
   toFunctionSelector,
   toHex,
 } from 'viem';
+import { unichain } from 'viem/chains';
 import type { CallTrace, TenderlySimulation } from '../../types.d';
 import type { CrossChainExecutionJob } from '../../types.d';
 
@@ -66,6 +67,8 @@ const L2_CROSS_CHAIN_ACCOUNT_FORWARD_ABI = parseAbi([
 const CROSS_CHAIN_FORWARD_SELECTOR = toFunctionSelector(
   'function forward(address target, bytes data)',
 );
+
+const UNICHAIN_CHAIN_ID = unichain.id;
 
 // Constants for validation
 const VALIDATION_CONSTANTS = {
@@ -306,7 +309,10 @@ function buildMessageFromDecodedPayload(input: {
     slice(input.messageData, 0, 4) === CROSS_CHAIN_FORWARD_SELECTOR &&
     (!expectedForwarder || getAddress(input.targetAddress) === getAddress(expectedForwarder));
 
-  // Decode forwarded payloads so we simulate and label the final target contract call.
+  // Decode forwarded payloads so we simulate the final target/data directly.
+  // Most OP chains execute the unwrapped call from a CrossChainAccount-style forwarder,
+  // but Unichain admin ownership is held by the aliased timelock, so its destination
+  // sim must preserve the original bridged sender instead of rewriting it to the forwarder.
   if (shouldAttemptForwardDecode) {
     try {
       const decodedForward = decodeFunctionData({
@@ -315,7 +321,9 @@ function buildMessageFromDecodedPayload(input: {
       });
       if (decodedForward.functionName === 'forward') {
         const [forwardTarget, forwardData] = decodedForward.args;
-        l2FromAddress = getAddress(input.targetAddress);
+        if (input.destinationChainId !== UNICHAIN_CHAIN_ID) {
+          l2FromAddress = getAddress(input.targetAddress);
+        }
         l2TargetAddress = getAddress(forwardTarget);
         l2InputData = forwardData as Hex;
       }


### PR DESCRIPTION
## Summary
- Preserve the original bridged sender when unwrapping forwarded Unichain OP messages
- Keep the final target/data decode for clearer destination sims

## Changes
- Treat Unichain forwarded calls as a sender-preserving exception in the OP bridge parser
- Add proposal parsing coverage for the Unichain forwarded-call case

## Test Plan
- bun run check:fix
- bun test checks/tests/cross-chain-bridge-parsing.test.ts
- MAINNET_RPC_URL=http://127.0.0.1:8545 ARBITRUM_RPC_URL=http://127.0.0.1:8545 ETHERSCAN_API_KEY=test TENDERLY_ACCESS_TOKEN=test TENDERLY_USER=test TENDERLY_PROJECT_SLUG=test bun test checks/tests/cross-chain-execution-engine.test.ts

Resolves #70