### PR TITLE
test: validate legacy bnb wormhole receiver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Testing:**
 - `cd checks && bun test` - Run all tests in checks directory
 - `cd checks && bun test <test-file>` - Run specific test file
+- `bun run test:wormhole:bnb-legacy:live` - Opt-in live validation for the legacy BNB Wormhole receiver assumptions
 
 **Running Specific Proposals:**
 - `bun run check-proposal <proposal-id>` - Run checks on specific proposal using environment variables

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ SIM_NAME=uni-transfer bun start
 
 Reports are saved to `reports/` folder.
 
+### 2a. Run the opt-in live BNB legacy Wormhole validation
+
+```bash
+# Load local RPC / explorer env first if your shell has not already done so
+set -a; source .env; set +a
+
+# Confirm the legacy BNB Wormhole receiver assumptions still match live chain state
+bun run test:wormhole:bnb-legacy:live
+```
+
+This check is intentionally opt-in. It validates the BNB authority ownership, confirms the
+modern receiver getters still revert, and verifies the legacy sequence storage slot remains
+readable onchain.
+
 ### 3. View results in the frontend
 
 ```bash

--- a/checks/tests/cross-chain-execution-engine.test.ts
+++ b/checks/tests/cross-chain-execution-engine.test.ts
@@ -11,8 +11,8 @@ import { bsc, mainnet, monad, polygon, tempo } from 'viem/chains';
 import type { TenderlySimulation } from '../../types.d';
 import { WORMHOLE_SEND_MESSAGE_ABI } from '../../utils/bridges/wormhole';
 import {
-  DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
-  WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+  LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
+  LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
 } from '../../utils/bridges/wormhole-runtime-state';
 import { createMockSimulation } from './test-utils';
 
@@ -25,7 +25,7 @@ process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
 
 const actualClientModule = await import('../../utils/clients/client');
 
-const RECEIVER_PAYLOAD_VERSION = DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
+const RECEIVER_PAYLOAD_VERSION = LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
 const TEMPO_RECEIVER = getAddress('0xCFB43dC56B55bE9611deD8384201cECf06A9811b');
 const CELO_RECEIVER = getAddress('0x0Eb863541278308c3A64F8E908BC646e27BFD071');
 const MONAD_RECEIVER = getAddress('0xe783de89a7f0408687f051e3e6d0beb62719ebad');
@@ -86,7 +86,7 @@ type ReceiverStorageRequest = {
 async function resolveMockedGetStorageAt(
   request: ReceiverStorageRequest,
 ): Promise<Hex | undefined> {
-  expect(request.slot).toBe(WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT);
+  expect(request.slot).toBe(LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT);
   if (getAddress(request.address) === BNB_RECEIVER) {
     return '0x0b';
   }
@@ -608,7 +608,7 @@ describe('cross-chain destination execution engine', () => {
         stateDiff: [
           {
             address: BNB_RECEIVER,
-            key: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+            key: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
             dirty: '0x0c',
           },
         ],
@@ -624,7 +624,7 @@ describe('cross-chain destination execution engine', () => {
     expect(mockedGetClientForChain).toHaveBeenCalledWith(bsc.id);
     expect(mockedGetStorageAt).toHaveBeenCalledWith({
       address: BNB_RECEIVER,
-      slot: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+      slot: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
       blockNumber: 100n,
     });
     expect(transportCalls[0]).toMatchObject({
@@ -671,7 +671,7 @@ describe('cross-chain destination execution engine', () => {
     expect(result.destinationJobResults[0]?.status).toBe('success');
     expect(
       result.destinationStateByChain[bsc.id]?.[BNB_RECEIVER]?.storage?.[
-        WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT
+        LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT
       ],
     ).toBe('0x0c');
   });
@@ -705,7 +705,7 @@ describe('cross-chain destination execution engine', () => {
           stateDiff: [
             {
               address: receiver,
-              key: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+              key: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
               dirty: '0x01',
             },
           ],
@@ -815,7 +815,7 @@ describe('cross-chain destination execution engine', () => {
         throw new Error('receiver storage unavailable');
       }
 
-      expect(request.slot).toBe(WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT);
+      expect(request.slot).toBe(LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT);
       return undefined;
     });
 
@@ -894,7 +894,7 @@ describe('cross-chain destination execution engine', () => {
         stateDiff: [
           {
             address: TEMPO_RECEIVER,
-            key: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+            key: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
             dirty: '0x01',
           },
         ],
@@ -939,7 +939,7 @@ describe('cross-chain destination execution engine', () => {
     const calldata = makeWormholeCalldata([{ target: bnbTarget, data: '0x8da5cb5b' }], 4);
 
     mockedGetStorageAt.mockImplementation(async (request) => {
-      expect(request.slot).toBe(WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT);
+      expect(request.slot).toBe(LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT);
       return undefined;
     });
 
@@ -959,7 +959,7 @@ describe('cross-chain destination execution engine', () => {
     const calldata = makeWormholeCalldata([{ target: bnbTarget, data: '0x8da5cb5b' }], 4);
 
     mockedGetStorageAt.mockImplementation(async (request) => {
-      expect(request.slot).toBe(WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT);
+      expect(request.slot).toBe(LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT);
       return '0x';
     });
 

--- a/checks/tests/wormhole-lane-validation.test.ts
+++ b/checks/tests/wormhole-lane-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseAbi } from 'viem';
+import { encodeAbiParameters, keccak256, parseAbi } from 'viem';
 import { config as proposal94TestConfig } from '../../sims/94-test.sim';
 import { config as proposal95TestConfig } from '../../sims/95-test.sim';
 import {
@@ -14,7 +14,11 @@ import {
 } from '../../tests/fixtures/test-only-wormhole-lane-state';
 import type { SimulationConfigNew, SimulationResult } from '../../types';
 import { getWormholeLaneCapabilities } from '../../utils/bridges/wormhole';
-import { WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT } from '../../utils/bridges/wormhole-runtime-state';
+import {
+  LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
+  LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
+} from '../../utils/bridges/wormhole-runtime-state';
+import { BlockExplorerFactory } from '../../utils/clients/block-explorers/factory';
 import { getClientForChain } from '../../utils/clients/client';
 import type { SimulationExecutionOptions } from '../../utils/clients/tenderly';
 import { handleCrossChainSimulations, simulateNew } from '../../utils/clients/tenderly';
@@ -29,11 +33,60 @@ import type { DerivedStateByChain } from '../../utils/derived-state';
 const OWNER_ABI = parseAbi(['function owner() view returns (address)']);
 const V2_FACTORY_ABI = parseAbi(['function feeToSetter() view returns (address)']);
 const EXTERNAL_API_TIMEOUT_MS = 180000;
+const RUN_LIVE_BNB_LEGACY_VALIDATION = process.env.RUN_LIVE_BNB_LEGACY_VALIDATION === '1';
+const maybeLiveBnbLegacy = RUN_LIVE_BNB_LEGACY_VALIDATION ? test : test.skip;
+const BNB_SOURCIFY_SOURCE_BASE_URL =
+  'https://repo.sourcify.dev/contracts/full_match/56/0x341c1511141022cf8eE20824Ae0fFA3491F1302b/sources';
+const LEGACY_BNB_WORMHOLE_PAYLOAD_DESCRIPTOR =
+  'UniswapWormholeMessageSenderV1 (bytes32 receivedMessagePayloadVersion, address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId)';
 
 type LaneKey = Extract<
   TestOnlyWormholeLaneKey,
   'bnb' | 'polygon' | 'avalanche' | 'celo' | 'monad' | 'tempo'
 >;
+
+async function expectLiveGovernanceAuthorityMatchesLane(laneKey: LaneKey): Promise<void> {
+  const lane = TEST_ONLY_WORMHOLE_LANES[laneKey];
+  const validationTargets = LIVE_WORMHOLE_LANE_VALIDATION_TARGETS[laneKey];
+  const client = getClientForChain(lane.chainId);
+
+  const feeToSetter = await client.readContract({
+    address: validationTargets.v2Factory,
+    abi: V2_FACTORY_ABI,
+    functionName: 'feeToSetter',
+  });
+
+  expect(feeToSetter.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
+
+  if (validationTargets.v3Factory) {
+    const owner = await client.readContract({
+      address: validationTargets.v3Factory,
+      abi: OWNER_ABI,
+      functionName: 'owner',
+    });
+    expect(owner.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
+  }
+
+  if (validationTargets.v4PoolManager) {
+    const owner = await client.readContract({
+      address: validationTargets.v4PoolManager,
+      abi: OWNER_ABI,
+      functionName: 'owner',
+    });
+    expect(owner.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
+  }
+}
+
+async function fetchLegacyBnbVerifiedSource(relativePath: string): Promise<string> {
+  const response = await fetch(`${BNB_SOURCIFY_SOURCE_BASE_URL}/${relativePath}`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch legacy BNB verified source ${relativePath}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return await response.text();
+}
 
 function buildExecutionOptions(
   config: SimulationConfigNew,
@@ -95,34 +148,9 @@ describe('Wormhole lane live authority validation', () => {
     'confirms the configured $chainName lane authority matches live destination governance state',
     async ({ laneKey }) => {
       const lane = TEST_ONLY_WORMHOLE_LANES[laneKey];
-      const validationTargets = LIVE_WORMHOLE_LANE_VALIDATION_TARGETS[laneKey];
       const client = getClientForChain(lane.chainId);
 
-      const feeToSetter = await client.readContract({
-        address: validationTargets.v2Factory,
-        abi: V2_FACTORY_ABI,
-        functionName: 'feeToSetter',
-      });
-
-      expect(feeToSetter.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
-
-      if (validationTargets.v3Factory) {
-        const owner = await client.readContract({
-          address: validationTargets.v3Factory,
-          abi: OWNER_ABI,
-          functionName: 'owner',
-        });
-        expect(owner.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
-      }
-
-      if (validationTargets.v4PoolManager) {
-        const owner = await client.readContract({
-          address: validationTargets.v4PoolManager,
-          abi: OWNER_ABI,
-          functionName: 'owner',
-        });
-        expect(owner.toLowerCase()).toBe(lane.l2FromAddress.toLowerCase());
-      }
+      await expectLiveGovernanceAuthorityMatchesLane(laneKey);
 
       const code = await client.getCode({ address: lane.l2FromAddress });
       expect(code).toBeDefined();
@@ -164,7 +192,7 @@ describe('Wormhole lane live authority validation', () => {
 
           const storedSequence = await client.getStorageAt({
             address: lane.l2FromAddress,
-            slot: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+            slot: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
           });
           expect(storedSequence).toBeDefined();
         } else {
@@ -192,6 +220,81 @@ describe('Wormhole lane live authority validation', () => {
           }),
         ).rejects.toThrow();
       }
+    },
+    EXTERNAL_API_TIMEOUT_MS,
+  );
+});
+
+describe('BNB legacy Wormhole live validation', () => {
+  maybeLiveBnbLegacy(
+    'confirms the legacy BNB receiver assumptions against live chain state',
+    async () => {
+      const lane = TEST_ONLY_WORMHOLE_LANES.bnb;
+      const client = getClientForChain(lane.chainId);
+      const laneCapabilities = getWormholeLaneCapabilities(lane.wormholeChainId);
+
+      await expectLiveGovernanceAuthorityMatchesLane('bnb');
+      if (laneCapabilities.kind !== 'legacy') {
+        throw new Error('Expected BNB to remain on the legacy Wormhole receiver path');
+      }
+
+      const verification = await BlockExplorerFactory.getContractVerification(
+        lane.l2FromAddress,
+        lane.chainId,
+      );
+      const contractName = await BlockExplorerFactory.fetchContractName(
+        lane.l2FromAddress,
+        lane.chainId,
+      );
+      const verifiedSource = await fetchLegacyBnbVerifiedSource(
+        'contracts/UniswapWormholeMessageReceiver.sol',
+      );
+      const externallyDerivedPayloadVersion = keccak256(
+        encodeAbiParameters([{ type: 'string' }], [LEGACY_BNB_WORMHOLE_PAYLOAD_DESCRIPTOR]),
+      );
+
+      expect(verification.status).toBe('verified');
+      expect(verification.source).toBe('sourcify');
+      expect(verification.sourcifyMatch).toBe('exact_match');
+      expect(contractName).toBe('UniswapWormholeMessageReceiver');
+      expect(verifiedSource).toContain(LEGACY_BNB_WORMHOLE_PAYLOAD_DESCRIPTOR);
+      expect(verifiedSource).toContain('uint64 nextMinimumSequence = 0;');
+      expect(verifiedSource).not.toContain('function nextMinimumSequence()');
+      expect(verifiedSource).not.toContain('EXPECTED_MESSAGE_PAYLOAD_VERSION');
+      expect(laneCapabilities.payloadVersion).toBe(LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION);
+      expect(externallyDerivedPayloadVersion).toBe(LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION);
+      expect(laneCapabilities.nextSequenceStorageSlot).toBe(
+        LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
+      );
+
+      await expect(
+        client.readContract({
+          address: lane.l2FromAddress,
+          abi: WORMHOLE_RECEIVER_ABI,
+          functionName: 'EXPECTED_MESSAGE_PAYLOAD_VERSION',
+        }),
+      ).rejects.toThrow();
+      await expect(
+        client.readContract({
+          address: lane.l2FromAddress,
+          abi: WORMHOLE_RECEIVER_ABI,
+          functionName: 'nextMinimumSequence',
+        }),
+      ).rejects.toThrow();
+
+      const storedSequence = await client.getStorageAt({
+        address: lane.l2FromAddress,
+        slot: laneCapabilities.nextSequenceStorageSlot,
+      });
+
+      expect(storedSequence).toBeDefined();
+      if (!storedSequence) {
+        throw new Error('Expected BNB legacy receiver sequence slot to be readable');
+      }
+      expect(storedSequence).toMatch(/^0x[0-9a-fA-F]{64}$/);
+      const parsedSequence = BigInt(storedSequence);
+      expect(parsedSequence).toBeGreaterThanOrEqual(0n);
+      expect(parsedSequence).toBeLessThanOrEqual(2n ** 64n - 1n);
     },
     EXTERNAL_API_TIMEOUT_MS,
   );

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check": "bun run typecheck && biome check",
     "check:fix": "bun run typecheck && biome check --write",
     "test": "bun test",
+    "test:wormhole:bnb-legacy:live": "RUN_LIVE_BNB_LEGACY_VALIDATION=1 bun test checks/tests/wormhole-lane-validation.test.ts -t 'BNB legacy Wormhole live validation'",
     "test:verifiers:live": "bun test tests/verifier-live-smoke.test.ts",
     "contract:check": "bun test checks/tests/report-json-contract.test.ts",
     "check-proposal": "bun run-checks.ts",

--- a/utils/bridges/wormhole-runtime-state.ts
+++ b/utils/bridges/wormhole-runtime-state.ts
@@ -1,6 +1,12 @@
-export const DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION =
+// BNB's live Uniswap governance authority is a legacy Wormhole receiver that does not expose
+// `EXPECTED_MESSAGE_PAYLOAD_VERSION`. This value is therefore a documented legacy assumption,
+// supported by the Tenderly/manual rollout evidence gathered during issue #232 and follow-up
+// issue #238. If that deployed receiver drifts, the dedicated BNB live validation should fail.
+export const LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION =
   '0x5b9c8ce5e2cddf4e51d4563526c39850198bb92458f003423543f7bfae0ffb1b' as const;
 
-// `nextMinimumSequence` is the first storage slot in the live Uniswap Wormhole receiver.
-export const WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT =
+// The same legacy BNB receiver stores `nextMinimumSequence` at storage slot 0 on the deployed
+// authority contract instead of exposing `nextMinimumSequence()`. The dedicated BNB live
+// validation checks that slot is still readable and parseable before we trust this layout.
+export const LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT =
   '0x0000000000000000000000000000000000000000000000000000000000000000' as const;

--- a/utils/bridges/wormhole.ts
+++ b/utils/bridges/wormhole.ts
@@ -2,8 +2,8 @@ import { decodeFunctionData, getAddress, isHex, parseAbi, slice, toFunctionSelec
 import { avalanche, bsc, celo, monad, polygon, tempo } from 'viem/chains';
 import type { CrossChainExecutionCall, CrossChainExecutionJob } from '../../types.d';
 import {
-  DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
-  WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+  LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
+  LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
 } from './wormhole-runtime-state';
 
 export const WORMHOLE_SEND_MESSAGE_ABI = parseAbi([
@@ -35,8 +35,8 @@ type LegacyReceiverWormholeLaneMetadata = DirectWormholeLaneMetadata & {
   receiverRuntimeState: {
     kind: 'legacy';
     receiverCoreAddress: `0x${string}`;
-    payloadVersion: typeof DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
-    nextSequenceStorageSlot: typeof WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT;
+    payloadVersion: typeof LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
+    nextSequenceStorageSlot: typeof LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT;
   };
 };
 
@@ -57,8 +57,8 @@ export type WormholeLaneCapabilities =
   | {
       kind: 'legacy';
       receiverCoreAddress: `0x${string}`;
-      payloadVersion: typeof DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
-      nextSequenceStorageSlot: typeof WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT;
+      payloadVersion: typeof LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION;
+      nextSequenceStorageSlot: typeof LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT;
     };
 
 export const SUPPORTED_WORMHOLE_CHAIN_IDS = [4, 5, 6, 14, 48, 68] as const;
@@ -75,9 +75,12 @@ const WORMHOLE_CHAIN_ID_TO_LANE_METADATA: Record<number, WormholeLaneMetadata> =
     receiverRuntimeState: {
       kind: 'legacy',
       receiverCoreAddress: getAddress('0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B'),
-      // BNB still uses an older receiver shape that does not expose the modern runtime-state getters.
-      payloadVersion: DEFAULT_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
-      nextSequenceStorageSlot: WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT,
+      // BNB still uses an older receiver shape that does not expose the modern runtime-state
+      // getters. We therefore keep the payload version and sequence slot as explicit metadata,
+      // with provenance documented in `wormhole-runtime-state.ts` and guarded by the opt-in
+      // live BNB validation test added for issue #238.
+      payloadVersion: LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
+      nextSequenceStorageSlot: LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT,
     },
   },
   5: {

--- a/utils/cross-chain/wormhole-receiver-sim.ts
+++ b/utils/cross-chain/wormhole-receiver-sim.ts
@@ -1,6 +1,6 @@
 import { type Address, type Hex, encodeAbiParameters, encodeFunctionData, parseAbi } from 'viem';
 import type { CrossChainExecutionJob } from '../../types.d';
-import { WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT } from '../bridges/wormhole-runtime-state';
+import { LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT } from '../bridges/wormhole-runtime-state';
 import type { SimulationStateObjects } from '../derived-state';
 
 export { WORMHOLE_CORE_STUB_RUNTIME_BYTECODE } from './wormhole-core-stub-bytecode';
@@ -23,7 +23,7 @@ export function getOverriddenWormholeReceiverSequence(
   receiverAddress: Address,
 ): bigint | null {
   const overriddenSequence =
-    workingState?.[receiverAddress]?.storage?.[WORMHOLE_RECEIVER_NEXT_MINIMUM_SEQUENCE_SLOT];
+    workingState?.[receiverAddress]?.storage?.[LEGACY_BNB_WORMHOLE_NEXT_MINIMUM_SEQUENCE_SLOT];
   if (overriddenSequence === undefined) return null;
   return BigInt(overriddenSequence);
 }


### PR DESCRIPTION
## Summary
- add an opt-in live validation for the legacy BNB Wormhole receiver
- derive the legacy BNB payload hash from Sourcify-verified source
- rename the legacy BNB runtime constants so they are explicitly lane-specific

## Changes
- add `bun run test:wormhole:bnb-legacy:live`
- validate BNB ownership, verification status, verified source shape, payload hash, and legacy sequence slot
- document the manual BNB validation command in the repo docs

## Test Plan
- `bun run test:wormhole:bnb-legacy:live`
- `bun test tests/wormhole-parser.test.ts checks/tests/cross-chain-execution-engine.test.ts`
- `bun run check`

Resolves #238