### PR TITLE
fix/state-change-reporting

### DIFF
--- a/checks/check-logs.ts
+++ b/checks/check-logs.ts
@@ -51,9 +51,8 @@ export const checkLogs: ProposalCheck = {
 
     // Parse each event
     for (const [address, logs] of Object.entries(allEvents)) {
-      // Use contracts array to get contract name of address
-      const contract = sim.contracts.find((c) => c.address === address);
-      info.push(await getContractName(contract, deps.chainConfig?.chainId));
+      const contract = sim.contracts.find((c) => getAddress(c.address) === address);
+      info.push(await getContractName(contract ?? { address }, deps.chainConfig?.chainId));
 
       // Format log data for report
       for (const log of logs) {

--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -84,9 +84,8 @@ export const checkStateChanges: ProposalCheck = {
     // Parse state changes at each address
     // ETH balance changes are now handled by the checkEthBalanceChanges module
     for (const [address, diffs] of Object.entries(stateDiffs)) {
-      // Use contracts array to get contract name of address
-      const contract = sim.contracts.find((c) => c.address === address);
-      info.push(await getContractName(contract, deps.chainConfig?.chainId));
+      const contract = sim.contracts.find((c) => getAddress(c.address) === address);
+      info.push(await getContractName(contract ?? { address }, deps.chainConfig?.chainId));
 
       // Track processed state changes to deduplicate
       const processedChanges = new Set<string>();
@@ -121,10 +120,7 @@ export const checkStateChanges: ProposalCheck = {
             info.push(`    \`${diff.soltype.name}\` changed from \`${oldVal}\` to \`${newVal}\``);
             processedChanges.add(changeKey);
           }
-        } else if (
-          diff.soltype.type === 'mapping (address => uint256)' ||
-          diff.soltype.type === 'mapping (uint256 => uint256)'
-        ) {
+        } else if (/^mapping \((address|uint\d+) => uint\d+\)$/.test(diff.soltype.type)) {
           // This is a complex type like a mapping, which may have multiple changes. The diff.original
           // and diff.dirty fields can be strings or objects, and for complex types they are objects,
           // so we cast them as such

--- a/checks/tests/check-state-changes.test.ts
+++ b/checks/tests/check-state-changes.test.ts
@@ -89,4 +89,83 @@ describe('checkStateChanges', () => {
     expect(result.info.join('\n')).toContain('Structured diff fallback for type `tuple`');
     expect(result.info.join('\n')).toContain('• Slot `0x01`: `0x00` → `0x01`');
   });
+
+  test('formats numeric mapping state diffs beyond uint256 as decoded key changes', async () => {
+    const contractAddress = '0x1111111111111111111111111111111111111111';
+    const holder = '0x2222222222222222222222222222222222222222';
+
+    const sim = createMockSimulation([]);
+    sim.contracts = [makeTenderlyContract(contractAddress, 'GovernanceToken')];
+    sim.transaction.transaction_info.state_diff = [
+      {
+        soltype: {
+          name: 'balances',
+          type: 'mapping (address => uint96)',
+          storage_location: 'default' as StateDiffSoltype['storage_location'],
+          components: null,
+          offset: 0,
+          index: '0',
+          indexed: false,
+        },
+        original: { [holder]: '1000000000000000000' },
+        dirty: { [holder]: '0' },
+        raw: [
+          {
+            address: contractAddress,
+            key: '0x01',
+            original: '0x0de0b6b3a7640000',
+            dirty: '0x00',
+          },
+        ],
+      },
+    ];
+
+    const deps = {
+      chainConfig: { chainId: 1 },
+      governor: { address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      timelock: { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+    } as unknown as ProposalData;
+
+    const result = await checkStateChanges.checkProposal({} as ProposalEvent, sim, deps);
+    const info = result.info.join('\n');
+
+    expect(result.warnings).toHaveLength(0);
+    expect(info).not.toContain('Structured diff fallback for type `mapping (address => uint96)`');
+    expect(info).toContain(
+      '`balances` key `0x2222222222222222222222222222222222222222` changed from `1000000000000000000` to `0`',
+    );
+  });
+
+  test('matches Tenderly contract metadata case-insensitively', async () => {
+    const contractAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+    const sim = createMockSimulation([]);
+    sim.contracts = [makeTenderlyContract(contractAddress, 'ExampleConfig')];
+    sim.transaction.transaction_info.state_diff = [
+      {
+        soltype: null,
+        original: '0x00',
+        dirty: '0x01',
+        raw: [
+          {
+            address: contractAddress,
+            key: '0x01',
+            original: '0x00',
+            dirty: '0x01',
+          },
+        ],
+      },
+    ];
+
+    const deps = {
+      governor: { address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      timelock: { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+    } as unknown as ProposalData;
+
+    const result = await checkStateChanges.checkProposal({} as ProposalEvent, sim, deps);
+
+    expect(result.info[0]).toBe(
+      'ExampleConfig at `0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD`',
+    );
+  });
 });

--- a/checks/tests/check-state-changes.test.ts
+++ b/checks/tests/check-state-changes.test.ts
@@ -164,8 +164,6 @@ describe('checkStateChanges', () => {
 
     const result = await checkStateChanges.checkProposal({} as ProposalEvent, sim, deps);
 
-    expect(result.info[0]).toBe(
-      'ExampleConfig at `0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD`',
-    );
+    expect(result.info[0]).toBe('ExampleConfig at `0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD`');
   });
 });

--- a/frontend/src/components/structured-report/StateChangeItem.tsx
+++ b/frontend/src/components/structured-report/StateChangeItem.tsx
@@ -34,6 +34,7 @@ export function StateChangeItem({
   const newValueCleaned = cleanValue(stateChange.newValue);
 
   const isHex32 = (value: string) => /^0x[0-9a-fA-F]{64}$/.test(value);
+  const isAddress = (value: string) => /^0x[0-9a-fA-F]{40}$/.test(value);
   const isDecimalInteger = (value: string) => /^-?\d+$/.test(value);
 
   const isUniswapV3Slot0Change =
@@ -43,7 +44,7 @@ export function StateChangeItem({
     /^0x0{64}$/i.test(stateChange.key);
 
   const isNumericChange = isDecimalInteger(oldValueCleaned) && isDecimalInteger(newValueCleaned);
-  const isAddressChange = oldValueCleaned.startsWith('0x') && newValueCleaned.startsWith('0x');
+  const isAddressChange = isAddress(oldValueCleaned) && isAddress(newValueCleaned);
   const isBooleanChange =
     (oldValueCleaned === 'true' || oldValueCleaned === 'false') &&
     (newValueCleaned === 'true' || newValueCleaned === 'false');
@@ -254,7 +255,7 @@ export function StateChangeItem({
         </div>
         <div className="flex items-center gap-2">
           <code className="text-xs bg-muted-foreground/20 px-2 py-1 rounded">
-            {stateChange.key}
+            {stateChange.label ?? stateChange.key}
           </code>
           {isExpanded ? (
             <ChevronUpIcon className="h-4 w-4 text-muted-foreground" />

--- a/frontend/src/hooks/use-simulation-results.ts
+++ b/frontend/src/hooks/use-simulation-results.ts
@@ -43,6 +43,7 @@ export interface SimulationStateChange {
   contract: string;
   contractAddress?: string;
   key: string;
+  label?: string;
   oldValue: string;
   newValue: string;
 }

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -597,9 +597,9 @@ function extractStateChanges(checks: AllCheckResults): SimulationStateChange[] {
         continue;
       }
 
-      // Try to extract slot changes: "    Slot `0xhash` changed from `"value"` to `"newvalue"`"
+      // Try to extract slot changes: "    Slot `0xhash` changed from `value` to `newvalue`"
       const slotChangeMatch = infoMsg.match(
-        /^\s+Slot `(0x[a-fA-F0-9]+)` changed from `"(.*?)"` to `"(.*?)"`$/,
+        /^\s+Slot `(0x[a-fA-F0-9]+)` changed from `([^`]*)` to `([^`]*)`$/,
       );
       if (slotChangeMatch) {
         stateChanges.push({
@@ -612,15 +612,32 @@ function extractStateChanges(checks: AllCheckResults): SimulationStateChange[] {
         continue;
       }
 
+      const fallbackSlotChangeMatch = infoMsg.match(
+        /^\s+• Slot `(0x[a-fA-F0-9]+)`: `([^`]*)` → `([^`]*)`$/,
+      );
+      if (fallbackSlotChangeMatch) {
+        stateChanges.push({
+          contract: currentContract,
+          contractAddress: currentContractAddress,
+          key: fallbackSlotChangeMatch[1],
+          oldValue: fallbackSlotChangeMatch[2],
+          newValue: fallbackSlotChangeMatch[3],
+        });
+        continue;
+      }
+
       // Try to extract mapping state changes: "`variable` key `key` changed from `value` to `newvalue`"
       const mappingStateChangeMatch = infoMsg.match(
-        /`(.+?)`\s+key\s+`(.+?)`\s+changed\s+from\s+`(.+?)`\s+to\s+`(.+?)`/,
+        /`([^`]+)`\s+key\s+`([^`]*)`\s+changed\s+from\s+`([^`]*)`\s+to\s+`([^`]*)`/,
       );
       if (mappingStateChangeMatch) {
+        const mappingName = mappingStateChangeMatch[1];
+        const mappingKey = mappingStateChangeMatch[2];
         stateChanges.push({
-          contract: currentContract || mappingStateChangeMatch[1],
+          contract: currentContract || mappingName,
           contractAddress: currentContractAddress,
-          key: mappingStateChangeMatch[2],
+          key: mappingKey,
+          label: `${mappingName}[${mappingKey}]`,
           oldValue: mappingStateChangeMatch[3],
           newValue: mappingStateChangeMatch[4],
         });

--- a/tests/state-change-extraction.test.ts
+++ b/tests/state-change-extraction.test.ts
@@ -56,8 +56,7 @@ describe('structured state change extraction', () => {
   });
 
   it('keeps raw slot changes in structured state changes', async () => {
-    const slot =
-      '0xc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b';
+    const slot = '0xc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b';
 
     const report = await generateStateChangeReport(outputDir, [
       'Franchiser at `0x3d4ACFD2C8b0641fb8db762179eE5A8dB385E573`',

--- a/tests/state-change-extraction.test.ts
+++ b/tests/state-change-extraction.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { GenerateReportsParams } from '../types';
+
+const proposal = {
+  id: 1n,
+  proposalId: 1n,
+  proposer: '0x1234567890123456789012345678901234567890',
+  startBlock: 1000n,
+  endBlock: 2000n,
+  description: '# Test Proposal\n\nThis is a test proposal.',
+  targets: ['0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+  values: [0n],
+  signatures: ['test()'],
+  calldatas: ['0x'],
+};
+
+const blocks = {
+  current: { number: 1500n, timestamp: 1700000000n },
+  start: { number: 1000n, timestamp: 1699000000n },
+  end: null,
+};
+
+async function generateStateChangeReport(outputDir: string, info: string[]) {
+  const { generateAndSaveReports } = await import('../presentation/report');
+
+  await generateAndSaveReports({
+    governorType: 'bravo',
+    blocks,
+    proposal,
+    checks: {
+      checkStateChanges: {
+        name: 'Reports all state changes from the proposal',
+        result: { info, warnings: [], errors: [] },
+      },
+    },
+    outputDir,
+    governorAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    simulationType: 'proposed',
+  } satisfies GenerateReportsParams);
+
+  return JSON.parse(readFileSync(join(outputDir, '1.json'), 'utf-8'));
+}
+
+describe('structured state change extraction', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-state-changes-'));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('keeps raw slot changes in structured state changes', async () => {
+    const slot =
+      '0xc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b';
+
+    const report = await generateStateChangeReport(outputDir, [
+      'Franchiser at `0x3d4ACFD2C8b0641fb8db762179eE5A8dB385E573`',
+      `    Slot \`${slot}\` changed from \`0x01\` to \`0x00\``,
+    ]);
+
+    expect(report.stateChanges).toContainEqual({
+      contract: 'Franchiser',
+      contractAddress: '0x3d4ACFD2C8b0641fb8db762179eE5A8dB385E573',
+      key: slot,
+      oldValue: '0x01',
+      newValue: '0x00',
+    });
+  });
+
+  it('preserves raw mapping keys and adds display labels', async () => {
+    const holder = '0x2222222222222222222222222222222222222222';
+
+    const report = await generateStateChangeReport(outputDir, [
+      'GovernanceToken at `0x1111111111111111111111111111111111111111`',
+      `    \`balances\` key \`${holder}\` changed from \`\` to \`7\``,
+    ]);
+
+    expect(report.stateChanges).toContainEqual({
+      contract: 'GovernanceToken',
+      contractAddress: '0x1111111111111111111111111111111111111111',
+      key: holder,
+      label: `balances[${holder}]`,
+      oldValue: '',
+      newValue: '7',
+    });
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -460,7 +460,7 @@ interface ABI {
 
 interface SoltypeElement {
   name: string;
-  type: SoltypeType;
+  type: TenderlySoltype;
   storage_location: StorageLocation;
   components: SoltypeElement[] | null;
   offset: number;
@@ -505,6 +505,8 @@ enum SoltypeType {
   Uint56 = 'uint56',
   Uint8 = 'uint8',
 }
+
+type TenderlySoltype = SoltypeType | `mapping (${string} => ${string})` | `uint${number}`;
 
 interface Output {
   name: string;
@@ -726,6 +728,7 @@ export interface SimulationStateChange {
   contract: string;
   contractAddress?: string;
   key: string;
+  label?: string;
   oldValue: string;
   newValue: string;
 }

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -967,13 +967,16 @@ async function findProposalCreatedEventNearBlock(params: {
   throw new Error(`Proposal creation log for #${proposalId} not found near block ${approxBlock}`);
 }
 
+type ContractNameInput = Pick<TenderlyContract, 'address'> &
+  Partial<Pick<TenderlyContract, 'contract_name' | 'token_data'>>;
+
 /**
- * @notice Given a Tenderly contract object, generates a descriptive human-friendly name for that contract
- * @param contract Tenderly contract object to generate name from
+ * @notice Generates a descriptive human-friendly name for a simulation contract address.
+ * @param contract Tenderly contract metadata, or an address-only object when Tenderly omitted metadata
  * @param chainId Optional chain ID to fetch better contract names from block explorers
  */
 export async function getContractName(
-  contract: TenderlyContract | undefined,
+  contract: ContractNameInput | undefined,
   chainId?: number,
 ): Promise<string> {
   if (!contract) return 'Unknown Contract';
@@ -1008,26 +1011,28 @@ export async function getContractName(
   // Best-effort fallback: Tenderly may not have indexed a verified contract yet, so try the
   // chain's configured block explorer for a better name when available.
   if (chainId && (contractName === 'Unknown Contract' || contractName.length === 0)) {
-    const memoryCached = CacheManager.getContractNameFromMemory(chainId, contractAddress);
-    if (memoryCached) {
-      contractName = memoryCached;
-    } else {
-      const fileCached = CacheManager.getContractNameFromFile(chainId, contractAddress);
-      if (fileCached) {
-        CacheManager.setContractNameInMemory(chainId, contractAddress, fileCached);
-        contractName = fileCached;
-      } else {
-        const fetched = await BlockExplorerFactory.fetchContractName(contractAddress, chainId);
-        if (fetched) {
-          CacheManager.setContractNameInMemory(chainId, contractAddress, fetched);
-          CacheManager.setContractNameInFile(chainId, contractAddress, fetched);
-          contractName = fetched;
-        }
-      }
-    }
+    contractName = (await fetchContractNameCached(contractAddress, chainId)) ?? contractName;
   }
 
   return `${contractName} at \`${contractAddress}\``;
+}
+
+async function fetchContractNameCached(address: Address, chainId: number): Promise<string | null> {
+  const memoryCached = CacheManager.getContractNameFromMemory(chainId, address);
+  if (memoryCached) return memoryCached;
+
+  const fileCached = CacheManager.getContractNameFromFile(chainId, address);
+  if (fileCached) {
+    CacheManager.setContractNameInMemory(chainId, address, fileCached);
+    return fileCached;
+  }
+
+  const fetched = await BlockExplorerFactory.fetchContractName(address, chainId);
+  if (!fetched) return null;
+
+  CacheManager.setContractNameInMemory(chainId, address, fetched);
+  CacheManager.setContractNameInFile(chainId, address, fetched);
+  return fetched;
 }
 
 /**


### PR DESCRIPTION
## Summary
- preserve raw fallback state diffs in structured reports
- decode numeric mapping state changes beyond uint256, including UNI uint96 balances
- fall back to explorer contract names when Tenderly omits metadata
- keep raw state-change keys while adding display labels for mapping entries

## Test plan
- bun test checks/tests/check-state-changes.test.ts tests/get-contract-name-fallback.test.ts tests/state-change-extraction.test.ts
- bun run typecheck
- (cd frontend && bun run typecheck)