### PR TITLE
feat: add polygon fx bridge adapter

### DIFF
--- a/checks/check-permission-diff.ts
+++ b/checks/check-permission-diff.ts
@@ -339,7 +339,28 @@ function hasOwnershipDiff(
 }
 
 function stableKey(item: PermissionsDiffItem): string {
-  return JSON.stringify(item, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
+  const contractAddress = item.contractAddress.toLowerCase();
+
+  switch (item.kind) {
+    case 'ownership_transferred':
+    case 'timelock_admin_changed':
+    case 'timelock_pending_admin_changed':
+      return [
+        item.kind,
+        contractAddress,
+        item.previous?.toLowerCase() ?? '',
+        item.next.toLowerCase(),
+      ].join(':');
+    case 'role_granted':
+    case 'role_revoked':
+      return [
+        item.kind,
+        contractAddress,
+        item.role.id.toLowerCase(),
+        item.account.toLowerCase(),
+        item.sender.toLowerCase(),
+      ].join(':');
+  }
 }
 
 function getContractNameFromSimulation(contract: TenderlyContract | undefined): string {

--- a/checks/tests/check-permission-diff.test.ts
+++ b/checks/tests/check-permission-diff.test.ts
@@ -202,6 +202,60 @@ describe('checkPermissionDiff', () => {
     });
   });
 
+  test('deduplicates ownership transfers detected from both event logs and state diffs', async () => {
+    const ownershipTopic0 = eventTopic('OwnershipTransferred(address,address)');
+    const contractOwnable = '0x1111111111111111111111111111111111111111';
+    const prevOwner = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const nextOwner = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    const sim = createSimulation({
+      logs: [
+        {
+          name: null,
+          anonymous: false,
+          inputs: [],
+          raw: {
+            address: contractOwnable,
+            topics: [ownershipTopic0, topicAddress(prevOwner), topicAddress(nextOwner)],
+            data: '0x',
+          },
+        },
+      ],
+      stateDiff: [
+        {
+          soltype: {
+            name: 'owner',
+            type: 'address',
+            storage_location: 'storage',
+            components: null,
+            offset: 0,
+            index: '0',
+            indexed: false,
+            simple_type: { type: 'address' },
+          },
+          original: prevOwner,
+          dirty: nextOwner,
+          raw: [{ address: contractOwnable, key: zeroHash, original: prevOwner, dirty: nextOwner }],
+        },
+      ],
+    });
+
+    const result = await checkPermissionDiff.checkProposal(
+      createProposalEvent(),
+      sim,
+      createDeps(1, 'https://etherscan.io'),
+    );
+
+    expect(result.permissionsDiff).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.permissionsDiff?.[0]).toMatchObject({
+      kind: 'ownership_transferred',
+      contractAddress: getAddress(contractOwnable),
+      previous: getAddress(prevOwner),
+      next: getAddress(nextOwner),
+    });
+  });
+
   test('detects ownership transfer via decoded-call + raw state diff fallback for non-canonical cases', async () => {
     const ownerChangedTopic0 = eventTopic('OwnerChanged(address,address)');
     const contract = '0x4b2ab38dbf28d31d467aa8993f6c2585981d6804';

--- a/checks/tests/cross-chain-execution-engine.test.ts
+++ b/checks/tests/cross-chain-execution-engine.test.ts
@@ -9,6 +9,12 @@ import {
 } from 'viem';
 import { bsc, celo, mainnet, monad, polygon, tempo } from 'viem/chains';
 import type { TenderlySimulation } from '../../types.d';
+import {
+  POLYGON_FX_CHILD,
+  POLYGON_FX_PROCESS_MESSAGE_ABI,
+  POLYGON_FX_ROOT,
+  POLYGON_FX_SEND_MESSAGE_ABI,
+} from '../../utils/bridges/polygon-fx';
 import { WORMHOLE_SEND_MESSAGE_ABI } from '../../utils/bridges/wormhole';
 import {
   LEGACY_BNB_WORMHOLE_MESSAGE_PAYLOAD_VERSION,
@@ -296,10 +302,11 @@ function makeWormholeCalldata(
 
 function makeSourceResult(
   calldatas: readonly `0x${string}`[],
-  options?: { simulationTimestamp?: bigint },
+  options?: { simulationTimestamp?: bigint; targets?: readonly `0x${string}`[] },
 ): CrossChainSourceResult {
   const sim = createMockSimulation([]);
   sim.transaction.status = true;
+  const targets = options?.targets ?? calldatas.map(() => WORMHOLE_PROPOSAL_TARGET);
 
   return {
     sim,
@@ -307,7 +314,7 @@ function makeSourceResult(
       id: 999n,
       proposalId: 999n,
       proposer: TIMELOCK_ADDRESS,
-      targets: calldatas.map(() => WORMHOLE_PROPOSAL_TARGET),
+      targets: [...targets],
       values: calldatas.map(() => 0n),
       signatures: calldatas.map(() => ''),
       calldatas: [...calldatas],
@@ -324,7 +331,7 @@ function makeSourceResult(
         blockExplorer: { baseUrl: 'https://etherscan.io' },
         rpcUrl: 'http://localhost:8545',
       },
-      targets: calldatas.map(() => WORMHOLE_PROPOSAL_TARGET),
+      targets: [...targets],
       touchedContracts: [],
     },
     latestBlock: {
@@ -336,6 +343,46 @@ function makeSourceResult(
 }
 
 describe('cross-chain destination execution engine', () => {
+  test('executes Polygon FxPortal messages through the FxChild handoff', async () => {
+    const polygonReceiver = getAddress('0x8a1B966aC46F42275860f905dbC75EfBfDC12374');
+    const childMessage = '0x12345678' as const;
+    const calldata = encodeFunctionData({
+      abi: POLYGON_FX_SEND_MESSAGE_ABI,
+      functionName: 'sendMessageToChild',
+      args: [polygonReceiver, childMessage],
+    });
+
+    enqueueSimulation(
+      makeSimulation({
+        id: 'polygon-fx-step',
+        chainId: polygon.id,
+      }),
+    );
+
+    const result = await handleCrossChainSimulations(
+      makeSourceResult([calldata], { targets: [POLYGON_FX_ROOT] }),
+    );
+
+    expect(mockedSendSimulation).toHaveBeenCalledTimes(1);
+    expect(transportCalls[0]).toMatchObject({
+      network_id: `${polygon.id}`,
+      from: POLYGON_FX_CHILD,
+      to: polygonReceiver,
+      value: '0',
+    });
+
+    const payloadInput = transportCalls[0]?.input;
+    expect(typeof payloadInput).toBe('string');
+    const decoded = decodeFunctionData({
+      abi: POLYGON_FX_PROCESS_MESSAGE_ABI,
+      data: payloadInput as Hex,
+    });
+    expect(decoded.functionName).toBe('processMessageFromRoot');
+    expect(decoded.args).toEqual([1n, getAddress(TIMELOCK_ADDRESS), childMessage]);
+    expect(result.destinationJobResults[0]?.bridgeType).toBe('PolygonFxL1L2');
+    expect(result.destinationJobResults[0]?.status).toBe('success');
+  });
+
   test('executes one simulated destination job per supported Wormhole lane', async () => {
     const calldatas = SUPPORTED_WORMHOLE_LANE_KEYS.map((laneKey) => {
       const lane = getWormholeLaneByKey(laneKey);

--- a/docs/API.md
+++ b/docs/API.md
@@ -208,7 +208,7 @@ export interface CrossChainJobPreview {
   chainId: number;
   chainName: string;
   blockExplorerBaseUrl: string;
-  bridgeType: string;                    // e.g. "ArbitrumL1L2" | "OptimismL1L2"
+  bridgeType: string;                    // e.g. "ArbitrumL1L2" | "OptimismL1L2" | "PolygonFxL1L2"
   status: 'success' | 'failure' | 'skipped';
   error?: string;
   l2FromAddress: `0x${string}`;

--- a/docs/CROSS_CHAIN.md
+++ b/docs/CROSS_CHAIN.md
@@ -6,10 +6,11 @@ This document describes the bridge architecture, supported Uniswap cross-chain l
 
 Seatbelt simulates a governance proposal on the source chain, extracts bridge-specific execution jobs, runs destination simulations, and produces one combined report.
 
-Today the tool supports three bridge families:
+Today the tool supports four bridge families:
 
 - `ArbitrumL1L2`
 - `OptimismL1L2`
+- `PolygonFxL1L2`
 - `WormholeL1L2`
 
 Cross-chain proposal support is intentionally lane-based. Seatbelt only guarantees behavior for the lanes that are explicitly configured and validated in code.
@@ -29,7 +30,7 @@ The execution engine in [tenderly-execution-engine.ts](../utils/cross-chain/tend
 ### Supported Bridge Types
 
 ```typescript
-type BridgeType = 'ArbitrumL1L2' | 'OptimismL1L2' | 'WormholeL1L2';
+type BridgeType = 'ArbitrumL1L2' | 'OptimismL1L2' | 'PolygonFxL1L2' | 'WormholeL1L2';
 ```
 
 ### ArbitrumL1L2
@@ -43,6 +44,12 @@ type BridgeType = 'ArbitrumL1L2' | 'OptimismL1L2' | 'WormholeL1L2';
 - Source bridge call: `L1CrossDomainMessenger.sendMessage(address,bytes,uint32)`
 - Address model: L1 sender is preserved on L2
 - Main job: extract messenger payload and simulate the L2 call
+
+### PolygonFxL1L2
+
+- Source bridge call: `FxRoot.sendMessageToChild(address,bytes)`
+- Address model: destination execution calls the Polygon receiver from canonical `FxChild`
+- Main job: wrap the Fx message as `processMessageFromRoot(stateId, rootMessageSender, data)` and simulate the Polygon-side handoff
 
 ### WormholeL1L2
 

--- a/tests/polygon-fx-parser.test.ts
+++ b/tests/polygon-fx-parser.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { decodeFunctionData, encodeAbiParameters, encodeFunctionData, getAddress } from 'viem';
+import {
+  POLYGON_FX_CHILD,
+  POLYGON_FX_PROCESS_MESSAGE_ABI,
+  POLYGON_FX_ROOT,
+  POLYGON_FX_SEND_MESSAGE_ABI,
+  extractPolygonFxL1L2JobsFromProposal,
+} from '../utils/bridges/polygon-fx';
+
+describe('polygon fx proposal parser', () => {
+  const timelock = getAddress('0x1a9C8182C09F50C8318d769245beA52c32BE35BC');
+  const ethereumProxy = getAddress('0x8a1B966aC46F42275860f905dbC75EfBfDC12374');
+  const v3Factory = getAddress('0x1F98431c8aD98523631AE4a59f267346ea31F984');
+
+  test('wraps FxRoot sendMessageToChild calldata as a Polygon processMessageFromRoot call', () => {
+    const childMessage = encodeAbiParameters(
+      [{ type: 'address[]' }, { type: 'bytes[]' }, { type: 'uint256[]' }],
+      [
+        [v3Factory],
+        ['0x13af40350000000000000000000000001111111111111111111111111111111111111111'],
+        [0n],
+      ],
+    );
+    const calldata = encodeFunctionData({
+      abi: POLYGON_FX_SEND_MESSAGE_ABI,
+      functionName: 'sendMessageToChild',
+      args: [ethereumProxy, childMessage],
+    });
+
+    const jobs = extractPolygonFxL1L2JobsFromProposal([POLYGON_FX_ROOT], [calldata], timelock);
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.bridgeType).toBe('PolygonFxL1L2');
+    expect(jobs[0]?.destinationChainId).toBe(137);
+    expect(jobs[0]?.l2FromAddress).toBe(POLYGON_FX_CHILD);
+    expect(jobs[0]?.sourceOrder).toBe(0);
+
+    const [call] = jobs[0]?.calls ?? [];
+    expect(call?.l2TargetAddress).toBe(ethereumProxy);
+    expect(call?.l2Value).toBe('0');
+
+    const decoded = decodeFunctionData({
+      abi: POLYGON_FX_PROCESS_MESSAGE_ABI,
+      data: call?.l2InputData ?? '0x',
+    });
+    expect(decoded.functionName).toBe('processMessageFromRoot');
+    expect(decoded.args).toEqual([1n, timelock, childMessage]);
+  });
+
+  test('ignores non-FxRoot proposal targets', () => {
+    const calldata = encodeFunctionData({
+      abi: POLYGON_FX_SEND_MESSAGE_ABI,
+      functionName: 'sendMessageToChild',
+      args: [ethereumProxy, '0x1234'],
+    });
+
+    const jobs = extractPolygonFxL1L2JobsFromProposal([v3Factory], [calldata], timelock);
+
+    expect(jobs).toHaveLength(0);
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -264,7 +264,7 @@ export interface AllCheckResults {
   [checkId: string]: { name: string; result: CheckResult };
 }
 
-export type BridgeType = 'ArbitrumL1L2' | 'OptimismL1L2' | 'WormholeL1L2';
+export type BridgeType = 'ArbitrumL1L2' | 'OptimismL1L2' | 'PolygonFxL1L2' | 'WormholeL1L2';
 
 /**
  * @notice One destination call executed inside a cross-chain execution job.

--- a/utils/bridges/adapter.ts
+++ b/utils/bridges/adapter.ts
@@ -4,6 +4,7 @@ import type { WormholeReceiverRuntimeStateByKey } from '../cross-chain/wormhole-
 import type { SimulationStateObjects } from '../derived-state';
 import { extractArbitrumL1L2JobsFromProposal } from './arbitrum';
 import { extractOptimismL1L2JobsFromProposal } from './optimism';
+import { extractPolygonFxL1L2JobsFromProposal } from './polygon-fx';
 import { extractWormholeExecutionJobsFromProposal } from './wormhole';
 import { prepareWormholeExecution } from './wormhole-execution';
 
@@ -16,6 +17,7 @@ export type CrossChainProposalExtractionContext = {
 type CrossChainBridgeRuntimeStoreByType = {
   ArbitrumL1L2: Record<string, unknown>;
   OptimismL1L2: Record<string, unknown>;
+  PolygonFxL1L2: Record<string, unknown>;
   WormholeL1L2: WormholeReceiverRuntimeStateByKey;
 };
 
@@ -59,6 +61,11 @@ const CROSS_CHAIN_BRIDGE_ADAPTERS: readonly CrossChainBridgeAdapter[] = [
     bridgeType: 'OptimismL1L2',
     extractJobs: ({ targets, calldatas, l1Sender }) =>
       extractOptimismL1L2JobsFromProposal(targets, calldatas, l1Sender),
+  },
+  {
+    bridgeType: 'PolygonFxL1L2',
+    extractJobs: ({ targets, calldatas, l1Sender }) =>
+      extractPolygonFxL1L2JobsFromProposal(targets, calldatas, l1Sender),
   },
   {
     bridgeType: 'WormholeL1L2',

--- a/utils/bridges/polygon-fx.ts
+++ b/utils/bridges/polygon-fx.ts
@@ -1,0 +1,113 @@
+import {
+  type Address,
+  type Hex,
+  decodeFunctionData,
+  encodeFunctionData,
+  getAddress,
+  isHex,
+  parseAbi,
+  slice,
+  toFunctionSelector,
+} from 'viem';
+import { polygon } from 'viem/chains';
+import type { CrossChainExecutionJob } from '../../types.d';
+
+export const POLYGON_FX_ROOT: Address = getAddress('0xfe5e5D361b2ad62c541bAb87C45a0B9B018389a2');
+export const POLYGON_FX_CHILD: Address = getAddress('0x8397259c983751DAf40400790063935a11afa28a');
+
+export const POLYGON_FX_SEND_MESSAGE_ABI = parseAbi([
+  'function sendMessageToChild(address receiver, bytes data)',
+]);
+
+export const POLYGON_FX_PROCESS_MESSAGE_ABI = parseAbi([
+  'function processMessageFromRoot(uint256 stateId, address rootMessageSender, bytes data)',
+]);
+
+const POLYGON_FX_SEND_MESSAGE_SELECTOR = toFunctionSelector(
+  'function sendMessageToChild(address receiver, bytes data)',
+);
+
+const ZERO_ADDRESS = getAddress('0x0000000000000000000000000000000000000000');
+
+function normalizeAddress(value: string): Address | null {
+  try {
+    return getAddress(value);
+  } catch {
+    return null;
+  }
+}
+
+function isPolygonFxRootCall(target: string, data: string): boolean {
+  if (!isHex(data) || data === '0x' || data.length < 10) {
+    return false;
+  }
+
+  const normalizedTarget = normalizeAddress(target);
+  if (!normalizedTarget || normalizedTarget.toLowerCase() !== POLYGON_FX_ROOT.toLowerCase()) {
+    return false;
+  }
+
+  return slice(data, 0, 4) === POLYGON_FX_SEND_MESSAGE_SELECTOR;
+}
+
+/**
+ * Extract Polygon FxPortal L1 -> L2 messages from proposal calldata.
+ *
+ * FxRoot forwards a root message to Polygon's FxChild, which then calls
+ * processMessageFromRoot(stateId, rootMessageSender, data) on the receiver.
+ * The destination simulation mirrors that Polygon-side handoff directly.
+ */
+export function extractPolygonFxL1L2JobsFromProposal(
+  targets: readonly string[],
+  calldatas: readonly string[],
+  l1Sender?: Address,
+): CrossChainExecutionJob[] {
+  const jobs: CrossChainExecutionJob[] = [];
+  const rootMessageSender = l1Sender ? getAddress(l1Sender) : ZERO_ADDRESS;
+
+  for (let i = 0; i < Math.min(targets.length, calldatas.length); i += 1) {
+    const target = targets[i];
+    const data = calldatas[i];
+    if (!target || !isPolygonFxRootCall(target, data)) continue;
+
+    try {
+      const decoded = decodeFunctionData({
+        abi: POLYGON_FX_SEND_MESSAGE_ABI,
+        data: data as Hex,
+      });
+
+      if (decoded.functionName !== 'sendMessageToChild') continue;
+
+      const [receiver, messageData] = decoded.args;
+      const l2InputData = encodeFunctionData({
+        abi: POLYGON_FX_PROCESS_MESSAGE_ABI,
+        functionName: 'processMessageFromRoot',
+        args: [BigInt(i + 1), rootMessageSender, messageData as Hex],
+      });
+
+      jobs.push({
+        bridgeType: 'PolygonFxL1L2',
+        destinationChainId: polygon.id,
+        l2FromAddress: POLYGON_FX_CHILD,
+        sourceOrder: i,
+        calls: [
+          {
+            l2TargetAddress: getAddress(receiver),
+            l2InputData,
+            l2Value: '0',
+          },
+        ],
+      });
+    } catch {
+      // Best-effort decode only; ignore malformed calldata and keep scanning.
+    }
+  }
+
+  if (jobs.length > 0) {
+    console.log(
+      `[Polygon Fx Parser] Extracted ${jobs.length} L1->L2 job(s) from proposal targets/calldatas.`,
+    );
+  }
+
+  return jobs;
+}


### PR DESCRIPTION
## Summary
- add a Polygon FxRoot/FxChild bridge adapter
- wrap FxRoot `sendMessageToChild` payloads as Polygon `processMessageFromRoot` calls
- cover parser and destination execution behavior

## Validation
- `bun test checks/tests/cross-chain-execution-engine.test.ts tests/polygon-fx-parser.test.ts`
- `bun run check`
- local `SIM_NAME=97` run with PR #262 sim copy produced 3 successful destination jobs after correcting the sim payload order

Note: the proposal 97 sim from #262 is intentionally excluded from this adapter PR.