### PR TITLE
fix: decode fallback event logs

### DIFF
--- a/checks/check-logs.ts
+++ b/checks/check-logs.ts
@@ -1,6 +1,85 @@
-import { getAddress } from 'viem';
-import type { Log, ProposalCheck } from '../types';
+import { type Abi, decodeEventLog, getAddress } from 'viem';
+import type { Log, ProposalCheck, TenderlyContract } from '../types';
+import { BlockExplorerFactory } from '../utils/clients/block-explorers/factory';
 import { getContractName } from '../utils/clients/tenderly';
+
+function isHex(value: unknown): value is `0x${string}` {
+  return typeof value === 'string' && /^0x[a-fA-F0-9]*$/.test(value);
+}
+
+function eventTopics(topics: unknown[]): [`0x${string}`, ...`0x${string}`[]] | null {
+  const [first, ...rest] = topics;
+  if (!isHex(first) || !rest.every(isHex)) return null;
+  return [first, ...rest];
+}
+
+function formatTenderlyDecodedLog(log: Log): string | null {
+  if (!log.name || !Array.isArray(log.inputs)) return null;
+
+  const parsedInputs = log.inputs
+    .map((input, index) => `${input.soltype?.name || `arg${index}`}: ${input.value}`)
+    .join(', ');
+  return `${log.name}(${parsedInputs})`;
+}
+
+function formatDecodedArgs(args: unknown): string {
+  if (Array.isArray(args)) {
+    return args.map((value, index) => `arg${index}: ${String(value)}`).join(', ');
+  }
+
+  if (args && typeof args === 'object') {
+    return Object.entries(args)
+      .map(([name, value]) => `${name}: ${String(value)}`)
+      .join(', ');
+  }
+
+  return '';
+}
+
+function formatAbiDecodedLog(log: Log, abi: Abi | null): string | null {
+  const topics = eventTopics(log.raw.topics);
+  if (!abi || !topics || !isHex(log.raw.data)) return null;
+
+  try {
+    const decoded = decodeEventLog({
+      abi,
+      data: log.raw.data,
+      topics,
+    });
+
+    return `${decoded.eventName}(${formatDecodedArgs(decoded.args)})`;
+  } catch {
+    return null;
+  }
+}
+
+function formatRawLog(log: Log): string {
+  const fields = [
+    ...log.raw.topics.map((topic, index) => `topic${index}: ${topic}`),
+    `data: ${log.raw.data}`,
+  ];
+
+  return `RawLog(${fields.join(', ')})`;
+}
+
+function formatLog(log: Log, abi: Abi | null): string {
+  return formatTenderlyDecodedLog(log) ?? formatAbiDecodedLog(log, abi) ?? formatRawLog(log);
+}
+
+function getTenderlyAbi(contract: TenderlyContract | undefined): Abi | null {
+  return contract?.data?.abi?.length ? (contract.data.abi as Abi) : null;
+}
+
+async function getLogDecodingAbi(
+  contract: TenderlyContract | undefined,
+  address: string,
+  chainId: number | undefined,
+): Promise<Abi | null> {
+  const tenderlyAbi = getTenderlyAbi(contract);
+  if (tenderlyAbi) return tenderlyAbi;
+  if (!chainId) return null;
+  return BlockExplorerFactory.fetchContractAbi(address, chainId);
+}
 
 /**
  * Reports all emitted events from the proposal
@@ -9,62 +88,32 @@ export const checkLogs: ProposalCheck = {
   name: 'Reports all events emitted from the proposal',
   async checkProposal(_, sim, deps, _l2Simulations) {
     const info: string[] = [];
-
-    // For L2 reports, only show logs from the destination simulation for this chain.
-    // Cross-chain destination simulations are rendered under their own chain sections.
-    const simulations = deps.chainConfig?.chainId !== 1 ? [sim] : [sim];
-
-    // Process all logs from all relevant simulations
     const allEvents: Record<string, Log[]> = {};
 
-    for (const currentSim of simulations) {
-      const events = currentSim.transaction.transaction_info.logs?.reduce(
-        (logs, log) => {
-          const addr = getAddress(log.raw.address);
-          // Check if this is a log that should be filtered out
-          const isGovernor = getAddress(addr) === deps.governor.address;
-          const isTimelock = getAddress(addr) === deps.timelock.address;
-          const shouldSkipLog =
-            (isGovernor && log.name === 'ProposalExecuted') ||
-            (isTimelock && log.name === 'ExecuteTransaction' && log.inputs.length === 0);
-          // Skip logs as required and add the rest to our logs object
-          if (shouldSkipLog) return logs;
-          if (!logs[addr]) logs[addr] = [];
-          logs[addr].push(log);
-          return logs;
-        },
-        {} as Record<string, Log[]>,
-      );
-
-      // Merge events from this simulation into allEvents
-      if (events) {
-        for (const [address, logs] of Object.entries(events)) {
-          if (!allEvents[address]) allEvents[address] = [];
-          allEvents[address].push(...logs);
-        }
-      }
+    for (const log of sim.transaction.transaction_info.logs ?? []) {
+      const addr = getAddress(log.raw.address);
+      const isGovernor = getAddress(addr) === deps.governor.address;
+      const isTimelock = getAddress(addr) === deps.timelock.address;
+      const shouldSkipLog =
+        (isGovernor && log.name === 'ProposalExecuted') ||
+        (isTimelock && log.name === 'ExecuteTransaction' && log.inputs.length === 0);
+      if (shouldSkipLog) continue;
+      if (!allEvents[addr]) allEvents[addr] = [];
+      allEvents[addr].push(log);
     }
 
-    // Return if no events to show
     if (!Object.keys(allEvents).length)
       return { info: ['No events emitted'], warnings: [], errors: [] };
 
-    // Parse each event
     for (const [address, logs] of Object.entries(allEvents)) {
       const contract = sim.contracts.find((c) => getAddress(c.address) === address);
       info.push(await getContractName(contract ?? { address }, deps.chainConfig?.chainId));
+      const abi = logs.some((log) => !formatTenderlyDecodedLog(log))
+        ? await getLogDecodingAbi(contract, address, deps.chainConfig?.chainId)
+        : null;
 
-      // Format log data for report
       for (const log of logs) {
-        if (log.name) {
-          // Log is decoded, format data as: VotingDelaySet(oldVotingDelay: value, newVotingDelay: value)
-          const parsedInputs = log.inputs.map((i) => `${i.soltype!.name}: ${i.value}`).join(', ');
-          info.push(`    \`${log.name}(${parsedInputs})\``);
-        } else {
-          // Log is not decoded, report the raw data
-          // TODO find a transaction with undecoded logs to know how topics/data are formatted in simulation response
-          info.push(`    Undecoded log: \`${JSON.stringify(log)}\``);
-        }
+        info.push(`    \`${formatLog(log, abi)}\``);
       }
     }
 

--- a/checks/tests/check-logs.test.ts
+++ b/checks/tests/check-logs.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test';
+import { encodeEventTopics, getAddress, parseAbi } from 'viem';
+import type { ProposalData, ProposalEvent, TenderlySimulation } from '../../types';
+import { CacheManager } from '../../utils/clients/block-explorers/cache';
+import { checkLogs } from '../check-logs';
+import { createMockSimulation } from './test-utils';
+
+type SimulationLog = NonNullable<
+  TenderlySimulation['transaction']['transaction_info']['logs']
+>[number];
+
+const OWNER_CHANGED_ABI = parseAbi([
+  'event OwnerChanged(address indexed oldOwner, address indexed newOwner)',
+]);
+const MYSTERY_EVENT_ABI = parseAbi(['event MysteryEvent(address indexed account)']);
+
+function topicStrings(topics: ReturnType<typeof encodeEventTopics>): string[] {
+  const strings: string[] = [];
+  for (const topic of topics) {
+    if (typeof topic !== 'string') throw new Error('Expected a concrete event topic');
+    strings.push(topic);
+  }
+  return strings;
+}
+
+function createProposalEvent(): ProposalEvent {
+  return {
+    id: 1n,
+    proposalId: 1n,
+    proposer: '0x0000000000000000000000000000000000000001',
+    startBlock: 1n,
+    endBlock: 2n,
+    description: 'test proposal',
+    targets: [],
+    values: [],
+    signatures: [],
+    calldatas: [],
+  };
+}
+
+function createDeps(chainId: number): ProposalData {
+  return {
+    governor: { address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+    timelock: { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+    publicClient: null,
+    chainConfig: {
+      chainId,
+      blockExplorer: { baseUrl: 'https://example.invalid' },
+      rpcUrl: 'https://example.invalid',
+    },
+    targets: [],
+    touchedContracts: [],
+  };
+}
+
+function createSimulationLog({
+  address,
+  topics,
+  data = '0x',
+  name = '',
+}: {
+  address: string;
+  topics: string[];
+  data?: string;
+  name?: string | null;
+}): SimulationLog {
+  return {
+    name,
+    anonymous: false,
+    inputs: [],
+    raw: { address, topics, data },
+  };
+}
+
+describe('checkLogs', () => {
+  test('decodes raw event logs when an ABI is available', async () => {
+    const v3Factory = getAddress('0xAfE208a311B21f13EF87E33A90049fC17A7acDEc');
+    const oldOwner = getAddress('0x0Eb863541278308c3A64F8E908BC646e27BFD071');
+    const newOwner = getAddress('0xB9952C01830306ea2fAAe1505f6539BD260Bfc48');
+
+    CacheManager.clearMemory();
+    CacheManager.setAbiInMemory(1, v3Factory, OWNER_CHANGED_ABI);
+    CacheManager.setContractNameInMemory(1, v3Factory, 'UniswapV3Factory');
+
+    const sim = createMockSimulation([]);
+    sim.transaction.transaction_info.logs = [
+      createSimulationLog({
+        address: v3Factory,
+        topics: topicStrings(
+          encodeEventTopics({
+            abi: OWNER_CHANGED_ABI,
+            eventName: 'OwnerChanged',
+            args: { oldOwner, newOwner },
+          }),
+        ),
+      }),
+    ];
+
+    const result = await checkLogs.checkProposal(createProposalEvent(), sim, createDeps(1));
+    const info = result.info.join('\n');
+
+    expect(result.errors).toHaveLength(0);
+    expect(info).toContain('UniswapV3Factory at `0xAfE208a311B21f13EF87E33A90049fC17A7acDEc`');
+    expect(info).toContain(
+      '`OwnerChanged(oldOwner: 0x0Eb863541278308c3A64F8E908BC646e27BFD071, newOwner: 0xB9952C01830306ea2fAAe1505f6539BD260Bfc48)`',
+    );
+    expect(info).not.toContain('RawLog');
+  });
+
+  test('keeps unknown raw logs visible as event rows', async () => {
+    const emitter = getAddress('0x1111111111111111111111111111111111111111');
+    const indexedValue = getAddress('0x2222222222222222222222222222222222222222');
+
+    const sim = createMockSimulation([]);
+    sim.transaction.transaction_info.logs = [
+      createSimulationLog({
+        address: emitter,
+        topics: topicStrings(
+          encodeEventTopics({
+            abi: MYSTERY_EVENT_ABI,
+            eventName: 'MysteryEvent',
+            args: { account: indexedValue },
+          }),
+        ),
+        data: '0x1234',
+      }),
+    ];
+
+    const result = await checkLogs.checkProposal(createProposalEvent(), sim, createDeps(0));
+    const info = result.info.join('\n');
+
+    expect(result.errors).toHaveLength(0);
+    expect(info).toContain('Unknown Contract at `0x1111111111111111111111111111111111111111`');
+    expect(info).toContain('`RawLog(topic0:');
+    expect(info).toContain(
+      'topic1: 0x0000000000000000000000002222222222222222222222222222222222222222',
+    );
+    expect(info).toContain('data: 0x1234)`');
+    expect(info).not.toContain('Undecoded log');
+  });
+});

--- a/frontend/src/components/CallGroupedView.test.tsx
+++ b/frontend/src/components/CallGroupedView.test.tsx
@@ -6,7 +6,10 @@ import type {
 } from '@/hooks/use-simulation-results';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { encodeEventTopics, getAddress, parseAbi } from 'viem';
 import { CallGroupedView } from './CallGroupedView';
+
+const MYSTERY_EVENT_ABI = parseAbi(['event MysteryEvent(address indexed account)']);
 
 function makeJob(
   overrides: Partial<CrossChainJobPreview> = {},
@@ -134,5 +137,55 @@ describe('CallGroupedView cross-chain summary headers', () => {
     expect(html).toContain('setFeeTo');
     expect(html).toContain('forward(address,bytes)');
     expect(html).toContain('0x3333333333333333333333333333333333333333');
+  });
+});
+
+describe('CallGroupedView event rendering', () => {
+  it('keeps legacy undecoded log rows visible under the emitting contract', () => {
+    const emitter = '0x1111111111111111111111111111111111111111';
+    const account = getAddress('0x2222222222222222222222222222222222222222');
+    const rawLog = JSON.stringify({
+      raw: {
+        topics: encodeEventTopics({
+          abi: MYSTERY_EVENT_ABI,
+          eventName: 'MysteryEvent',
+          args: { account },
+        }),
+        data: '0x1234',
+      },
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(CallGroupedView, {
+        proposal: {
+          id: '1',
+          targets: [emitter],
+          values: [0n],
+          calldatas: ['0x'],
+          signatures: [''],
+          description: 'Events proposal',
+        },
+        report: {
+          ...makeReport([]),
+          checks: [
+            {
+              checkId: 'checkLogs',
+              title: 'Reports all events emitted from the proposal',
+              status: 'passed',
+              info: [`MysteryEmitter at \`${emitter}\``, `    Undecoded log: \`${rawLog}\``],
+              warnings: [],
+              errors: [],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html).toContain('1 event');
+    expect(html).toContain('RawLog');
+    expect(html).toContain('Could not decode');
+    expect(html).toContain('topic0');
+    expect(html).toContain(account.slice(2).toLowerCase());
+    expect(html).toContain('0x1234');
   });
 });

--- a/frontend/src/components/CallGroupedView.tsx
+++ b/frontend/src/components/CallGroupedView.tsx
@@ -9,6 +9,7 @@ import type {
   StructuredSimulationReport,
 } from '@/hooks/use-simulation-results';
 import { resolveChainName } from '@/lib/chain-name';
+import { formatRawLogFromJson } from '@/lib/raw-log';
 import { CheckIcon, ChevronDownIcon, CopyIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -384,6 +385,12 @@ function parseLogsByEmitter(checks: SimulationCheck[]) {
     const eventLine = line.match(/^\s+`(.+?)`$/);
     if (eventLine && currentAddress) {
       byAddress.get(currentAddress)?.events.push(eventLine[1]);
+      continue;
+    }
+
+    const legacyUndecodedLine = line.match(/^\s+Undecoded log:\s+`(.+?)`$/);
+    if (legacyUndecodedLine && currentAddress) {
+      byAddress.get(currentAddress)?.events.push(formatRawLogFromJson(legacyUndecodedLine[1]));
     }
   }
 
@@ -572,8 +579,23 @@ function EventCard({
   }
 
   const hasParams = parsed.params.length > 0;
+  const couldNotDecode = parsed.name === 'RawLog';
+  const couldNotDecodeBadge = couldNotDecode ? (
+    <Badge
+      variant="outline"
+      className="bg-yellow-100 text-yellow-800 border-yellow-300 text-[10px] px-1.5 py-0"
+    >
+      Could not decode
+    </Badge>
+  ) : null;
+
   if (!hasParams) {
-    return <div className="text-xs font-medium text-foreground">{parsed.name}</div>;
+    return (
+      <div className="flex items-center gap-2 text-xs">
+        <span className="font-medium text-foreground">{parsed.name}</span>
+        {couldNotDecodeBadge}
+      </div>
+    );
   }
 
   return (
@@ -581,6 +603,7 @@ function EventCard({
       <summary className="cursor-pointer select-none flex items-center gap-2 text-xs [&::-webkit-details-marker]:hidden">
         <ChevronDownIcon className="h-3 w-3 text-muted-foreground transition-transform group-open:rotate-180 shrink-0" />
         <span className="font-medium text-foreground">{parsed.name}</span>
+        {couldNotDecodeBadge}
         <span className="text-muted-foreground">({parsed.params.length} params)</span>
       </summary>
       <div className="mt-1.5 ml-5 space-y-1 border-l-2 border-muted/50 pl-3">

--- a/frontend/src/components/structured-report/EventsDisplay.tsx
+++ b/frontend/src/components/structured-report/EventsDisplay.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge';
 import type { StructuredSimulationReport } from '@/hooks/use-simulation-results';
+import { formatRawLogFromJson } from '@/lib/raw-log';
 import { ExternalLinkIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { buildAddressLink } from './explorer';
@@ -38,7 +39,9 @@ function parseEventsFromDetails(details: string): ParsedEvent[] {
       continue;
     }
 
-    const eventMatch = cleanLine.match(/^\s*`?(\w+)\((.+)\)`?\s*$/);
+    const legacyUndecodedLog = cleanLine.match(/^Undecoded log:\s+`(.+)`$/);
+    const eventLine = legacyUndecodedLog ? formatRawLogFromJson(legacyUndecodedLog[1]) : cleanLine;
+    const eventMatch = eventLine.match(/^\s*`?(\w+)\((.+)\)`?\s*$/);
     if (eventMatch && currentContract) {
       const eventName = eventMatch[1];
       const paramsString = eventMatch[2];
@@ -117,6 +120,14 @@ export function EventsDisplay({
                   <Badge variant="outline" className="font-mono text-xs">
                     {event.name}
                   </Badge>
+                  {event.name === 'RawLog' && (
+                    <Badge
+                      variant="outline"
+                      className="bg-yellow-100 text-yellow-800 border-yellow-300 text-xs"
+                    >
+                      Could not decode
+                    </Badge>
+                  )}
                 </div>
                 {event.params.length > 0 && (
                   <div className="space-y-1">

--- a/frontend/src/components/structured-report/FormattedCheckDetails.test.ts
+++ b/frontend/src/components/structured-report/FormattedCheckDetails.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { encodeEventTopics, getAddress, parseAbi } from 'viem';
 import { FormattedCheckDetails } from './FormattedCheckDetails';
+
+const MYSTERY_EVENT_ABI = parseAbi(['event MysteryEvent(address indexed account)']);
 
 function countOccurrences(source: string, token: string): number {
   return source.split(token).length - 1;
@@ -91,5 +94,48 @@ describe('FormattedCheckDetails target row rendering', () => {
     ).toBe(1);
     expect(html).toContain('EOA (may have code later)');
     expect(html).not.toContain(`[\`${address}\`](https://celoscan.io/address/${address})`);
+  });
+});
+
+describe('FormattedCheckDetails event rendering', () => {
+  it('keeps legacy undecoded logs visible in event checks', () => {
+    const emitter = '0x1111111111111111111111111111111111111111';
+    const account = getAddress('0x2222222222222222222222222222222222222222');
+    const rawLog = JSON.stringify({
+      raw: {
+        topics: encodeEventTopics({
+          abi: MYSTERY_EVENT_ABI,
+          eventName: 'MysteryEvent',
+          args: { account },
+        }),
+        data: '0x1234',
+      },
+    });
+    const details = [
+      `**Info**: MysteryEmitter at \`${emitter}\``,
+      `**Info**:     Undecoded log: \`${rawLog}\``,
+    ].join('\n');
+
+    const html = renderToStaticMarkup(
+      createElement(FormattedCheckDetails, {
+        check: {
+          title: 'Reports all events emitted from the proposal',
+          status: 'passed',
+          details,
+        },
+        metadata: {
+          proposalId: '123',
+          proposer: '0x0000000000000000000000000000000000000001',
+        },
+      }),
+    );
+
+    expect(html).toContain('MysteryEmitter');
+    expect(html).toContain('RawLog');
+    expect(html).toContain('Could not decode');
+    expect(html).toContain('topic0');
+    expect(html).toContain(account.slice(2).toLowerCase());
+    expect(html).toContain('0x1234');
+    expect(html).not.toContain('No events to display');
   });
 });

--- a/frontend/src/lib/raw-log.test.ts
+++ b/frontend/src/lib/raw-log.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { encodeEventTopics, getAddress, parseAbi } from 'viem';
+import { formatRawLogFromJson } from './raw-log';
+
+const MYSTERY_EVENT_ABI = parseAbi(['event MysteryEvent(address indexed account)']);
+
+describe('formatRawLogFromJson', () => {
+  it('keeps raw logs visible', () => {
+    const account = getAddress('0x2222222222222222222222222222222222222222');
+    const rawLog = JSON.stringify({
+      raw: {
+        topics: encodeEventTopics({
+          abi: MYSTERY_EVENT_ABI,
+          eventName: 'MysteryEvent',
+          args: { account },
+        }),
+        data: '0x1234',
+      },
+    });
+
+    const formatted = formatRawLogFromJson(rawLog);
+
+    expect(formatted).toContain('RawLog(topic0: 0x');
+    expect(formatted).toContain('topic1: 0x');
+    expect(formatted).toContain(account.slice(2).toLowerCase());
+    expect(formatted).toContain('data: 0x1234)');
+  });
+
+  it('keeps malformed raw logs visible', () => {
+    expect(formatRawLogFromJson('not json')).toBe('Undecoded log: not json');
+  });
+});

--- a/frontend/src/lib/raw-log.ts
+++ b/frontend/src/lib/raw-log.ts
@@ -1,0 +1,28 @@
+function hasRawLog(value: unknown): value is { raw: { topics: unknown[]; data?: unknown } } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'raw' in value &&
+    typeof value.raw === 'object' &&
+    value.raw !== null &&
+    'topics' in value.raw &&
+    Array.isArray(value.raw.topics)
+  );
+}
+
+export function formatRawLogFromJson(rawJson: string) {
+  try {
+    const log: unknown = JSON.parse(rawJson);
+    if (!hasRawLog(log)) return `Undecoded log: ${rawJson}`;
+
+    const fields = log.raw.topics
+      .filter((topic): topic is string => typeof topic === 'string')
+      .map((topic, index) => `topic${index}: ${topic}`);
+
+    if (typeof log.raw.data === 'string') fields.push(`data: ${log.raw.data}`);
+
+    return fields.length ? `RawLog(${fields.join(', ')})` : `Undecoded log: ${rawJson}`;
+  } catch {
+    return `Undecoded log: ${rawJson}`;
+  }
+}


### PR DESCRIPTION
## Summary
- decode raw event logs with known contract/local ABIs when Tenderly leaves them blank
- render unknown logs as raw event rows instead of hiding them behind empty contract headers
- keep legacy undecoded-log artifacts visible in the frontend

## Test
- bun test checks/tests/check-logs.test.ts
- bun test frontend/src/components/CallGroupedView.test.tsx
- bun run check
- (frontend) bun run check