### PR TITLE
fix: show cross-chain destination calls

### DIFF
--- a/frontend/src/components/CallGroupedView.test.tsx
+++ b/frontend/src/components/CallGroupedView.test.tsx
@@ -15,6 +15,11 @@ function makeJob(
   overrides: Partial<CrossChainJobPreview> = {},
   signatures: string[] = ['bridgeAction()'],
 ): CrossChainJobPreview {
+  const targets = [
+    '0x2222222222222222222222222222222222222222',
+    '0x3333333333333333333333333333333333333333',
+  ] as const;
+
   return {
     chainId: 42161,
     chainName: 'Arbitrum',
@@ -26,10 +31,10 @@ function makeJob(
     steps: signatures.map((signature, index) => ({
       stepIndex: index,
       status: 'success',
-      l2TargetAddress: '0x2222222222222222222222222222222222222222',
+      l2TargetAddress: targets[index] ?? targets[0],
       l2Value: '0',
       l2InputData: `0x${String(index + 1).padStart(8, '0')}`,
-      targetLabel: 'Arbitrum target',
+      targetLabel: `Arbitrum target ${index + 1}`,
       call: {
         selector: `0x${String(index + 1).padStart(8, '0')}`,
         signature,
@@ -119,6 +124,12 @@ describe('CallGroupedView cross-chain summary headers', () => {
     expect(html).toContain('bridgeFirst');
     expect(html).toContain('bridgeSecond');
     expect(html).toContain('cleanup');
+    expect(html).toContain('3 cross-chain destination calls');
+    expect(html).toContain('2 destination calls');
+    expect(html).toContain('Arbitrum target 1');
+    expect(html).toContain('Arbitrum target 2');
+    expect(html).toContain('0x2222222222222222222222222222222222222222');
+    expect(html).toContain('0x3333333333333333333333333333333333333333');
     expect(html).toContain(
       'inline-flex items-center justify-center h-5 w-5 rounded bg-muted text-[10px] font-semibold text-muted-foreground shrink-0',
     );

--- a/frontend/src/components/CallGroupedView.tsx
+++ b/frontend/src/components/CallGroupedView.tsx
@@ -677,9 +677,12 @@ export function CallGroupedView({
 
   // Summary stats
   const crossChainJobs = report.crossChain?.jobs ?? [];
+  const crossChainDestinationCalls = crossChainJobs.reduce(
+    (total, job) => total + job.steps.length,
+    0,
+  );
   const totalMainnetCalls = calls.length;
-  const totalCrossChainCalls = crossChainJobs.length;
-  const totalCalls = totalMainnetCalls + totalCrossChainCalls;
+  const totalCalls = totalMainnetCalls + crossChainDestinationCalls;
   const totalEthValue = calls.reduce((sum, c) => sum + c.value, 0n);
   const allTags = calls.flatMap((c) => c.tags);
   const tagCounts = allTags.reduce<Record<RiskTag, number>>(
@@ -717,9 +720,10 @@ export function CallGroupedView({
           {totalEthValue > 0n && (
             <span className="text-muted-foreground">{formatEthValue(totalEthValue)} total</span>
           )}
-          {totalCrossChainCalls > 0 && (
+          {crossChainJobs.length > 0 && (
             <span className="text-muted-foreground">
-              {totalCrossChainCalls} cross-chain ({crossChainChains.size} chain
+              {crossChainDestinationCalls} cross-chain destination call
+              {crossChainDestinationCalls === 1 ? '' : 's'} ({crossChainChains.size} chain
               {crossChainChains.size === 1 ? '' : 's'})
               {crossChainFailures > 0 && (
                 <Badge variant="destructive" className="ml-1 text-[10px] px-1.5">
@@ -1008,9 +1012,7 @@ function CrossChainCallsSection({
             </div>
 
             {chainJobs.map((job) => {
-              const firstStep = job.steps[0];
-              const target = firstStep ? getCrossChainStepTarget(firstStep) : undefined;
-              const targetLabel = firstStep ? getCrossChainStepTargetLabel(firstStep) : undefined;
+              const stepCount = job.steps.length;
 
               return (
                 <div
@@ -1019,22 +1021,9 @@ function CrossChainCallsSection({
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2 min-w-0">
-                      {target ? (
-                        <AddressValue
-                          address={target}
-                          baseUrl={explorerBaseUrl}
-                          labels={labels}
-                          chainId={chainId}
-                          variant="header"
-                        />
-                      ) : (
-                        <span className="text-sm text-muted-foreground">Unknown target</span>
-                      )}
-                      {target && targetLabel && !getAddressLabelFor(target, labels) && (
-                        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                          {targetLabel}
-                        </Badge>
-                      )}
+                      <span className="text-sm font-medium">
+                        {stepCount} destination call{stepCount === 1 ? '' : 's'}
+                      </span>
                       {job.status === 'skipped' && (
                         <Badge variant="outline" className="text-[10px] px-1.5 py-0">
                           Skipped
@@ -1055,121 +1044,166 @@ function CrossChainCallsSection({
                   )}
 
                   <div className="space-y-2">
-                    {job.steps.map((msg, index) => {
-                      const visibleSignature = formatCrossChainCall(msg);
-                      const transportLabel = getCrossChainTransportLabel(msg);
-                      const fnName = visibleSignature.split('(')[0] || 'Call';
-                      const hasValue = msg.l2Value && msg.l2Value !== '0';
-                      const isFailed = msg.status === 'failure';
+                    {stepCount ? (
+                      job.steps.map((msg, index) => {
+                        const visibleSignature = formatCrossChainCall(msg);
+                        const transportLabel = getCrossChainTransportLabel(msg);
+                        const stepTarget = getCrossChainStepTarget(msg);
+                        const stepTargetLabel = getCrossChainStepTargetLabel(msg);
+                        const fnName = visibleSignature.split('(')[0] || 'Call';
+                        const hasValue = msg.l2Value && msg.l2Value !== '0';
+                        const isFailed = msg.status === 'failure';
 
-                      return (
-                        <details
-                          key={`${chainId}-${job.sourceOrder}-${index}`}
-                          className={`group border rounded ${isFailed ? 'border-red-200 bg-red-50/50' : 'border-muted/60'}`}
-                        >
-                          <summary className="cursor-pointer select-none px-2.5 py-1.5 flex items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
-                            <div className="min-w-0 flex items-baseline gap-2">
-                              <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-muted text-[10px] font-semibold text-muted-foreground shrink-0">
-                                {index + 1}
-                              </span>
-                              <span className="text-sm font-medium">{fnName}</span>
-                              {hasValue && (
-                                <span className="text-xs text-muted-foreground">
-                                  {msg.l2Value} wei
+                        return (
+                          <details
+                            key={`${chainId}-${job.sourceOrder}-${index}`}
+                            className={`group border rounded ${isFailed ? 'border-red-200 bg-red-50/50' : 'border-muted/60'}`}
+                          >
+                            <summary className="cursor-pointer select-none px-2.5 py-1.5 flex items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
+                              <div className="min-w-0 flex items-center gap-2">
+                                <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-muted text-[10px] font-semibold text-muted-foreground shrink-0">
+                                  {index + 1}
                                 </span>
-                              )}
-                              {isFailed && (
-                                <Badge variant="destructive" className="text-[10px] px-1.5">
-                                  Failed
-                                </Badge>
-                              )}
-                            </div>
-                            <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground transition-transform group-open:rotate-180 shrink-0" />
-                          </summary>
-
-                          <div className="px-3 pb-3 pt-1 space-y-1.5 text-xs">
-                            {job.l2FromAddress && (
-                              <div className="flex items-center gap-3">
-                                <span className="text-muted-foreground w-14 shrink-0">From</span>
-                                <AddressValue
-                                  address={job.l2FromAddress}
-                                  baseUrl={explorerBaseUrl}
-                                  labels={labels}
-                                  chainId={chainId}
-                                />
-                              </div>
-                            )}
-
-                            {visibleSignature && (
-                              <div className="flex items-start gap-3">
-                                <span className="text-muted-foreground w-14 shrink-0">Sig</span>
-                                <code className="font-mono text-[11px] break-all">
-                                  {visibleSignature}
-                                </code>
-                              </div>
-                            )}
-
-                            {transportLabel && transportLabel !== visibleSignature && (
-                              <div className="flex items-start gap-3">
-                                <span className="text-muted-foreground w-14 shrink-0">Via</span>
-                                <code className="font-mono text-[11px] break-all">
-                                  {transportLabel}
-                                </code>
-                              </div>
-                            )}
-
-                            {msg.call?.args && msg.call.args.length > 0 && (
-                              <div className="space-y-1">
-                                {msg.call.args.map((arg, argIndex) => {
-                                  const raw = stringifyDecodedValue(arg);
-                                  const looksLikeAddress = isHexAddress(raw);
-
-                                  return (
-                                    <div
-                                      key={`${chainId}-${job.sourceOrder}-${index}-arg-${argIndex}`}
-                                      className="flex items-center gap-3"
-                                    >
-                                      <span className="text-muted-foreground w-14 shrink-0 truncate">
-                                        arg{argIndex}
+                                <span className="text-sm font-medium truncate">{fnName}</span>
+                                {stepTarget ? (
+                                  <span className="inline-flex items-center gap-1 min-w-0">
+                                    {stepTargetLabel ? (
+                                      <span className="text-xs text-muted-foreground truncate">
+                                        {stepTargetLabel}
                                       </span>
-                                      {looksLikeAddress ? (
-                                        <AddressValue
-                                          address={raw}
-                                          baseUrl={explorerBaseUrl}
-                                          labels={labels}
-                                          chainId={chainId}
-                                        />
-                                      ) : (
-                                        <ValueWithCopy value={raw} />
-                                      )}
-                                    </div>
-                                  );
-                                })}
+                                    ) : null}
+                                    <ExplorerAddressLink
+                                      address={stepTarget}
+                                      baseUrl={explorerBaseUrl}
+                                      className="text-xs font-mono text-muted-foreground hover:underline shrink-0"
+                                    >
+                                      {stepTarget.slice(0, 6)}...{stepTarget.slice(-4)}
+                                    </ExplorerAddressLink>
+                                  </span>
+                                ) : (
+                                  <span className="text-xs text-muted-foreground">
+                                    Unknown target
+                                  </span>
+                                )}
+                                {hasValue && (
+                                  <span className="text-xs text-muted-foreground">
+                                    {msg.l2Value} wei
+                                  </span>
+                                )}
+                                {isFailed && (
+                                  <Badge variant="destructive" className="text-[10px] px-1.5">
+                                    Failed
+                                  </Badge>
+                                )}
                               </div>
-                            )}
+                              <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground transition-transform group-open:rotate-180 shrink-0" />
+                            </summary>
 
-                            {msg.error && (
-                              <div className="mt-2 p-2 bg-red-100 border border-red-200 rounded text-red-800 text-[11px]">
-                                {msg.error}
-                              </div>
-                            )}
+                            <div className="px-3 pb-3 pt-1 space-y-1.5 text-xs">
+                              {stepTarget && (
+                                <div className="flex items-center gap-3">
+                                  <span className="text-muted-foreground w-14 shrink-0">To</span>
+                                  <AddressValue
+                                    address={stepTarget}
+                                    baseUrl={explorerBaseUrl}
+                                    labels={labels}
+                                    chainId={chainId}
+                                  />
+                                  {stepTargetLabel && !getAddressLabelFor(stepTarget, labels) ? (
+                                    <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                                      {stepTargetLabel}
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                              )}
 
-                            {msg.l2InputData && (
-                              <details className="mt-2">
-                                <summary className="cursor-pointer text-muted-foreground hover:text-foreground text-[11px]">
-                                  Raw data
-                                </summary>
-                                <div className="mt-1 pl-2 border-l border-muted">
-                                  <code className="font-mono text-[11px] break-all text-muted-foreground">
-                                    {msg.l2InputData}
+                              {job.l2FromAddress && (
+                                <div className="flex items-center gap-3">
+                                  <span className="text-muted-foreground w-14 shrink-0">From</span>
+                                  <AddressValue
+                                    address={job.l2FromAddress}
+                                    baseUrl={explorerBaseUrl}
+                                    labels={labels}
+                                    chainId={chainId}
+                                  />
+                                </div>
+                              )}
+
+                              {visibleSignature && (
+                                <div className="flex items-start gap-3">
+                                  <span className="text-muted-foreground w-14 shrink-0">Sig</span>
+                                  <code className="font-mono text-[11px] break-all">
+                                    {visibleSignature}
                                   </code>
                                 </div>
-                              </details>
-                            )}
-                          </div>
-                        </details>
-                      );
-                    })}
+                              )}
+
+                              {transportLabel && transportLabel !== visibleSignature && (
+                                <div className="flex items-start gap-3">
+                                  <span className="text-muted-foreground w-14 shrink-0">Via</span>
+                                  <code className="font-mono text-[11px] break-all">
+                                    {transportLabel}
+                                  </code>
+                                </div>
+                              )}
+
+                              {msg.call?.args && msg.call.args.length > 0 && (
+                                <div className="space-y-1">
+                                  {msg.call.args.map((arg, argIndex) => {
+                                    const raw = stringifyDecodedValue(arg);
+                                    const looksLikeAddress = isHexAddress(raw);
+
+                                    return (
+                                      <div
+                                        key={`${chainId}-${job.sourceOrder}-${index}-arg-${argIndex}`}
+                                        className="flex items-center gap-3"
+                                      >
+                                        <span className="text-muted-foreground w-14 shrink-0 truncate">
+                                          arg{argIndex}
+                                        </span>
+                                        {looksLikeAddress ? (
+                                          <AddressValue
+                                            address={raw}
+                                            baseUrl={explorerBaseUrl}
+                                            labels={labels}
+                                            chainId={chainId}
+                                          />
+                                        ) : (
+                                          <ValueWithCopy value={raw} />
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              )}
+
+                              {msg.error && (
+                                <div className="mt-2 p-2 bg-red-100 border border-red-200 rounded text-red-800 text-[11px]">
+                                  {msg.error}
+                                </div>
+                              )}
+
+                              {msg.l2InputData && (
+                                <details className="mt-2">
+                                  <summary className="cursor-pointer text-muted-foreground hover:text-foreground text-[11px]">
+                                    Raw data
+                                  </summary>
+                                  <div className="mt-1 pl-2 border-l border-muted">
+                                    <code className="font-mono text-[11px] break-all text-muted-foreground">
+                                      {msg.l2InputData}
+                                    </code>
+                                  </div>
+                                </details>
+                              )}
+                            </div>
+                          </details>
+                        );
+                      })
+                    ) : (
+                      <div className="rounded border border-muted/60 px-2.5 py-2 text-xs text-muted-foreground">
+                        No destination calls decoded
+                      </div>
+                    )}
                   </div>
                 </div>
               );

--- a/frontend/src/components/structured-report/CrossChainPreview.test.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.test.tsx
@@ -8,6 +8,11 @@ function makeJob(
   overrides: Partial<CrossChainJobPreview> = {},
   stepCount = 1,
 ): CrossChainJobPreview {
+  const targets = [
+    '0x2222222222222222222222222222222222222222',
+    '0x3333333333333333333333333333333333333333',
+  ] as const;
+
   return {
     chainId: 42161,
     chainName: 'Arbitrum',
@@ -19,10 +24,10 @@ function makeJob(
     steps: Array.from({ length: stepCount }, (_, index) => ({
       stepIndex: index,
       status: 'success',
-      l2TargetAddress: '0x2222222222222222222222222222222222222222',
+      l2TargetAddress: targets[index] ?? targets[0],
       l2Value: '0',
       l2InputData: '0x12345678',
-      targetLabel: 'Arbitrum target',
+      targetLabel: `Arbitrum target ${index + 1}`,
       call: {
         selector: '0x12345678',
         signature: `bridgeAction${index + 1}()`,
@@ -33,7 +38,7 @@ function makeJob(
 }
 
 describe('CrossChainPreview', () => {
-  it('omits step-count copy while preserving destination action content', () => {
+  it('renders every destination step without aggregate action labels', () => {
     const html = renderToStaticMarkup(
       createElement(CrossChainPreview, {
         jobs: [makeJob({}, 1), makeJob({ sourceOrder: 1 }, 2)],
@@ -41,8 +46,13 @@ describe('CrossChainPreview', () => {
     );
 
     expect(html).toContain('Arbitrum');
-    expect(html).toContain('Arbitrum target');
+    expect(html).toContain('Arbitrum target 1');
+    expect(html).toContain('Arbitrum target 2');
     expect(html).toContain('bridgeAction1()');
+    expect(html).toContain('bridgeAction2()');
+    expect(html).toContain('0x2222222222222222222222222222222222222222');
+    expect(html).toContain('0x3333333333333333333333333333333333333333');
+    expect(html).toContain('2 destination calls');
     expect(html).not.toContain('Action 1');
     expect(html).not.toContain('Action 2');
     expect(html).not.toContain('Execution 2');

--- a/frontend/src/components/structured-report/CrossChainPreview.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.tsx
@@ -14,6 +14,34 @@ import {
 } from './cross-chain';
 import { buildAddressLinkForExplorer } from './explorer';
 
+function CrossChainStatusBadge({
+  status,
+}: {
+  status: CrossChainJobPreview['status'];
+}) {
+  if (status === 'success') {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-800 border-emerald-300 text-[10px] h-5 px-1.5">
+        OK
+      </Badge>
+    );
+  }
+
+  if (status === 'skipped') {
+    return (
+      <Badge variant="outline" className="text-[10px] h-5 px-1.5">
+        Skipped
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive" className="text-[10px] h-5 px-1.5">
+      Failed
+    </Badge>
+  );
+}
+
 export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
   const groups = useMemo(() => {
     const byChain = new Map<number, CrossChainJobPreview[]>();
@@ -52,61 +80,82 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
 
             <div className="space-y-2">
               {chainJobs.map((job) => {
-                const firstStep = job.steps[0];
                 const jobKey = `${job.chainId}-${job.bridgeType}-${job.sourceOrder}-${job.l2FromAddress}-${job.status}`;
-                const target = firstStep ? getCrossChainStepTarget(firstStep) : undefined;
-                const targetLabel = firstStep ? getCrossChainStepTargetLabel(firstStep) : undefined;
-                const call = firstStep ? formatCrossChainCall(firstStep) : '(empty job)';
-                const transportLabel = firstStep ? getCrossChainTransportLabel(firstStep) : null;
-
-                const statusBadge =
-                  job.status === 'success' ? (
-                    <Badge className="bg-emerald-100 text-emerald-800 border-emerald-300 text-[10px] h-5 px-1.5">
-                      OK
-                    </Badge>
-                  ) : job.status === 'skipped' ? (
-                    <Badge variant="outline" className="text-[10px] h-5 px-1.5">
-                      Skipped
-                    </Badge>
-                  ) : (
-                    <Badge variant="destructive" className="text-[10px] h-5 px-1.5">
-                      Failed
-                    </Badge>
-                  );
+                const stepCount = job.steps.length;
 
                 return (
                   <div key={jobKey} className="border border-border/40 rounded bg-muted/20 p-2.5">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2 text-xs">
-                        {targetLabel ? <span className="font-medium">{targetLabel}</span> : null}
-                        {target ? (
-                          <a
-                            href={buildAddressLinkForExplorer(target, explorerBaseUrl)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-mono text-[10px] text-muted-foreground hover:text-foreground inline-flex items-center"
-                            title={target}
-                          >
-                            {target.slice(0, 6)}...{target.slice(-4)}
-                            <ExternalLinkIcon className="h-2.5 w-2.5 ml-0.5" />
-                          </a>
-                        ) : (
-                          <span className="text-muted-foreground text-[10px]">
-                            (unknown target)
-                          </span>
-                        )}
+                      <div className="text-xs font-medium">
+                        {stepCount} destination call{stepCount === 1 ? '' : 's'}
                       </div>
-                      {statusBadge}
+                      <CrossChainStatusBadge status={job.status} />
                     </div>
 
-                    <code className="block mt-1.5 font-mono text-[10px] text-muted-foreground truncate">
-                      {call}
-                    </code>
-                    {transportLabel ? (
-                      <div className="mt-1 text-[10px] text-muted-foreground">
-                        via <code className="font-mono">{transportLabel}</code>
+                    {stepCount ? (
+                      <div className="mt-2 space-y-2">
+                        {job.steps.map((step, index) => {
+                          const target = getCrossChainStepTarget(step);
+                          const targetLabel = getCrossChainStepTargetLabel(step);
+                          const call = formatCrossChainCall(step);
+                          const transportLabel = getCrossChainTransportLabel(step);
+
+                          return (
+                            <div
+                              key={`${jobKey}-${step.stepIndex}-${index}`}
+                              className="rounded border border-border/30 bg-background/70 p-2"
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <div className="flex items-center gap-2 text-xs min-w-0">
+                                  <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded bg-muted text-[10px] font-semibold text-muted-foreground">
+                                    {index + 1}
+                                  </span>
+                                  {targetLabel ? (
+                                    <span className="font-medium truncate">{targetLabel}</span>
+                                  ) : null}
+                                  {target ? (
+                                    <a
+                                      href={buildAddressLinkForExplorer(target, explorerBaseUrl)}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="font-mono text-[10px] text-muted-foreground hover:text-foreground inline-flex items-center shrink-0"
+                                      title={target}
+                                    >
+                                      {target.slice(0, 6)}...{target.slice(-4)}
+                                      <ExternalLinkIcon className="h-2.5 w-2.5 ml-0.5" />
+                                    </a>
+                                  ) : (
+                                    <span className="text-muted-foreground text-[10px]">
+                                      (unknown target)
+                                    </span>
+                                  )}
+                                </div>
+                                {step.status !== 'success' ? (
+                                  <CrossChainStatusBadge status={step.status} />
+                                ) : null}
+                              </div>
+
+                              <code className="block mt-1.5 font-mono text-[10px] text-muted-foreground truncate">
+                                {call}
+                              </code>
+                              {transportLabel ? (
+                                <div className="mt-1 text-[10px] text-muted-foreground">
+                                  via <code className="font-mono">{transportLabel}</code>
+                                </div>
+                              ) : null}
+
+                              {step.error ? (
+                                <div className="text-[10px] text-red-600 mt-1">{step.error}</div>
+                              ) : null}
+                            </div>
+                          );
+                        })}
                       </div>
-                    ) : null}
+                    ) : (
+                      <code className="block mt-1.5 font-mono text-[10px] text-muted-foreground truncate">
+                        (empty job)
+                      </code>
+                    )}
 
                     {job.error ? (
                       <div className="text-[10px] text-red-600 mt-1">{job.error}</div>

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -16,6 +16,7 @@ import type { Visitor } from 'unist-util-visit';
 import {
   type Abi,
   type Hex,
+  decodeAbiParameters,
   decodeFunctionData,
   getAddress,
   isHex,
@@ -25,6 +26,7 @@ import {
 import type {
   AllCheckResults,
   CoverageData,
+  CrossChainJobStepPreview,
   DerivedSimulationDependency,
   GenerateReportsParams,
   GovernorType,
@@ -96,6 +98,9 @@ const KNOWN_FUNCTION_SELECTORS: Record<string, string> = {
 const CONTRACT_ABI_CACHE = new Map<string, Abi | null>();
 const CONTRACT_ABI_PROMISE_CACHE = new Map<string, Promise<Abi | null>>();
 const FORWARD_ABI = parseAbi(['function forward(address target, bytes data)']);
+const POLYGON_FX_PROCESS_MESSAGE_ABI = parseAbi([
+  'function processMessageFromRoot(uint256 stateId, address rootMessageSender, bytes data)',
+]);
 
 function getContractAbiCacheKey(target: string, chainId: number): string {
   return `${chainId}:${target.toLowerCase()}`;
@@ -196,6 +201,44 @@ async function decodeForwardedContractCall(
   }
 }
 
+async function expandPolygonFxBatchPreviewStep(
+  step: CrossChainJobStepPreview,
+  chainId: number,
+  simulation: TenderlySimulation | undefined,
+): Promise<CrossChainJobStepPreview[]> {
+  try {
+    const decoded = decodeFunctionData({
+      abi: POLYGON_FX_PROCESS_MESSAGE_ABI,
+      data: step.l2InputData,
+    });
+    if (decoded.functionName !== 'processMessageFromRoot') return [step];
+
+    const [, , messageData] = decoded.args;
+    const [targets, calldatas] = decodeAbiParameters(
+      [{ type: 'address[]' }, { type: 'bytes[]' }],
+      messageData,
+    );
+    if (targets.length === 0 || targets.length !== calldatas.length) return [step];
+
+    return await Promise.all(
+      targets.map(async (target, index) => {
+        const calldata = calldatas[index];
+        const targetAddress = getAddress(target);
+        const forwardedCall = await decodeContractCall(targetAddress, calldata, chainId);
+
+        return {
+          ...step,
+          forwardedTargetAddress: targetAddress,
+          forwardedTargetLabel: getSimulationContractLabel(simulation, targetAddress),
+          forwardedCall: forwardedCall ?? undefined,
+        };
+      }),
+    );
+  } catch {
+    return [step];
+  }
+}
+
 function getSimulationContractLabel(
   simulation: TenderlySimulation | undefined,
   address: string | undefined,
@@ -227,7 +270,7 @@ async function buildCrossChainPreview(
     destinationJobResults.map(async (dest) => {
       const chainId = dest.chainId;
       const blockExplorerBaseUrl = getBlockExplorerBaseUrlForChain(chainId);
-      const steps = await Promise.all(
+      const previewStepGroups = await Promise.all(
         dest.job.calls.map(async (call, stepIndex) => {
           const step = dest.stepResults[stepIndex];
           const decoded = await decodeContractCall(call.l2TargetAddress, call.l2InputData, chainId);
@@ -239,7 +282,7 @@ async function buildCrossChainPreview(
             stepSimulation,
           );
 
-          return {
+          const previewStep: CrossChainJobStepPreview = {
             stepIndex,
             status: step?.status ?? dest.status,
             error,
@@ -254,8 +297,11 @@ async function buildCrossChainPreview(
             forwardedTargetLabel: forwarded?.targetLabel,
             forwardedCall: forwarded?.call,
           };
+
+          return await expandPolygonFxBatchPreviewStep(previewStep, chainId, stepSimulation);
         }),
       );
+      const steps = previewStepGroups.flat().map((step, stepIndex) => ({ ...step, stepIndex }));
 
       return {
         chainId,

--- a/tests/cross-chain-selector-fallback.test.ts
+++ b/tests/cross-chain-selector-fallback.test.ts
@@ -2,7 +2,16 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { type Address, type Hex, encodeFunctionData, parseAbi, zeroAddress, zeroHash } from 'viem';
+import {
+  type Address,
+  type Hex,
+  encodeAbiParameters,
+  encodeFunctionData,
+  getAddress,
+  parseAbi,
+  zeroAddress,
+  zeroHash,
+} from 'viem';
 import { createMockSimulation } from '../checks/tests/test-utils';
 import type { AllCheckResults, ProposalEvent, SimulationBlock, SimulationResult } from '../types';
 import { clearFunctionSignatureRegistryCache } from '../utils/clients/function-signature-registry';
@@ -92,7 +101,7 @@ describe('cross-chain selector fallback decode', () => {
     const destinationSimulation: NonNullable<SimulationResult['destinationJobResults']>[number] = {
       chainId: 196,
       bridgeType: 'OptimismL1L2',
-      status: 'success' as const,
+      status: 'success',
       job: {
         bridgeType: 'OptimismL1L2' as const,
         l2FromAddress,
@@ -269,6 +278,136 @@ describe('cross-chain selector fallback decode', () => {
     }
   }, 60000);
 
+  it('expands Polygon Fx batch previews into inner destination calls', async () => {
+    process.env.MAINNET_RPC_URL ??= 'http://localhost:8545';
+    process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
+    process.env.ETHERSCAN_API_KEY ??= 'test';
+    process.env.TENDERLY_ACCESS_TOKEN ??= 'test';
+    process.env.TENDERLY_USER ??= 'test';
+    process.env.TENDERLY_PROJECT_SLUG ??= 'test';
+
+    const { generateAndSaveReports } = await import('../presentation/report');
+    const { BlockExplorerFactory } = await import('../utils/clients/block-explorers/factory');
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-polygon-fx-preview-'));
+    const originalFetchContractAbi = BlockExplorerFactory.fetchContractAbi;
+
+    const receiver = getAddress('0x8a1B966aC46F42275860f905dbC75EfBfDC12374');
+    const v2Factory = getAddress('0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C');
+    const v3Factory = getAddress('0x1F98431c8aD98523631AE4a59f267346ea31F984');
+    const feeTo = getAddress('0xc6ae6373cecc9e595a6c8b9fe581925a8c84f70a');
+    const owner = getAddress('0x3f07f08b45912dcd6691c5b9412975d5113b2910');
+
+    const processMessageAbi = parseAbi([
+      'function processMessageFromRoot(uint256 stateId, address rootMessageSender, bytes data)',
+    ]);
+    const v2Abi = parseAbi(['function setFeeTo(address)']);
+    const v3Abi = parseAbi(['function setOwner(address)']);
+    const batchData = encodeAbiParameters(
+      [{ type: 'address[]' }, { type: 'bytes[]' }],
+      [
+        [v2Factory, v3Factory],
+        [
+          encodeFunctionData({ abi: v2Abi, functionName: 'setFeeTo', args: [feeTo] }),
+          encodeFunctionData({ abi: v3Abi, functionName: 'setOwner', args: [owner] }),
+        ],
+      ],
+    );
+    const l2InputData = encodeFunctionData({
+      abi: processMessageAbi,
+      functionName: 'processMessageFromRoot',
+      args: [1n, '0x1a9C8182C09F50C8318d769245beA52c32BE35BC', batchData],
+    });
+
+    const { proposal, blocks, checks } = buildFixture(receiver);
+    const stepSim = createMockSimulation([]);
+    stepSim.contracts = [
+      makeTenderlyContract(receiver, 'EthereumProxy'),
+      makeTenderlyContract(v2Factory, 'UniswapV2Factory'),
+      makeTenderlyContract(v3Factory, 'UniswapV3Factory'),
+    ];
+    stepSim.transaction.transaction_info.logs = [];
+
+    const destinationSimulation: NonNullable<SimulationResult['destinationJobResults']>[number] = {
+      chainId: 137,
+      bridgeType: 'PolygonFxL1L2',
+      status: 'success' as const,
+      job: {
+        bridgeType: 'PolygonFxL1L2',
+        l2FromAddress: '0x8397259c983751DAf40400790063935a11afa28a',
+        destinationChainId: 137,
+        sourceOrder: 0,
+        calls: [
+          {
+            l2TargetAddress: receiver,
+            l2InputData,
+            l2Value: '0',
+          },
+        ],
+      },
+      stepResults: [
+        {
+          stepIndex: 0,
+          call: {
+            l2TargetAddress: receiver,
+            l2InputData,
+            l2Value: '0',
+          },
+          status: 'success',
+          sim: stepSim,
+        },
+      ],
+      accumulatedSim: stepSim,
+    };
+
+    BlockExplorerFactory.fetchContractAbi = async (target) => {
+      const address = getAddress(target);
+      if (address === receiver) return processMessageAbi;
+      if (address === v2Factory) return v2Abi;
+      if (address === v3Factory) return v3Abi;
+      return null;
+    };
+
+    try {
+      await generateAndSaveReports({
+        governorType: 'bravo',
+        blocks,
+        proposal,
+        checks,
+        outputDir,
+        governorAddress: '0x9876543210fedcba9876543210fedcba98765432',
+        destinationJobResults: [destinationSimulation],
+      });
+
+      const structuredReportPath = join(outputDir, '181.json');
+      const structuredReport = JSON.parse(readFileSync(structuredReportPath, 'utf8')) as {
+        crossChain?: {
+          jobs?: Array<{
+            steps?: Array<{
+              forwardedTargetAddress?: string;
+              forwardedTargetLabel?: string;
+              forwardedCall?: { signature?: string };
+              call?: { signature?: string };
+            }>;
+          }>;
+        };
+      };
+
+      const steps = structuredReport.crossChain?.jobs?.[0]?.steps ?? [];
+      expect(steps).toHaveLength(2);
+      expect(steps[0]?.call?.signature).toBe('processMessageFromRoot(uint256,address,bytes)');
+      expect(steps[0]?.forwardedTargetAddress).toBe(v2Factory);
+      expect(steps[0]?.forwardedTargetLabel).toBe('UniswapV2Factory');
+      expect(steps[0]?.forwardedCall?.signature).toBe('setFeeTo(address)');
+      expect(steps[1]?.forwardedTargetAddress).toBe(v3Factory);
+      expect(steps[1]?.forwardedTargetLabel).toBe('UniswapV3Factory');
+      expect(steps[1]?.forwardedCall?.signature).toBe('setOwner(address)');
+    } finally {
+      BlockExplorerFactory.fetchContractAbi = originalFetchContractAbi;
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  }, 60000);
+
   it('does not mark conceptual forwarded calls as failed when receiver-mode job succeeded', async () => {
     process.env.MAINNET_RPC_URL ??= 'http://localhost:8545';
     process.env.ARBITRUM_RPC_URL ??= 'http://localhost:8545';
@@ -278,7 +417,9 @@ describe('cross-chain selector fallback decode', () => {
     process.env.TENDERLY_PROJECT_SLUG ??= 'test';
 
     const { generateAndSaveReports } = await import('../presentation/report');
+    const { BlockExplorerFactory } = await import('../utils/clients/block-explorers/factory');
     const outputDir = mkdtempSync(join(tmpdir(), 'seatbelt-cross-chain-forwarded-status-'));
+    const originalFetchContractAbi = BlockExplorerFactory.fetchContractAbi;
     const { proposal, blocks, checks } = buildFixture();
     const forwardAbi = parseAbi(['function forward(address target, bytes data)']);
     const ownerAbi = parseAbi(['function setOwner(address _owner)']);
@@ -349,6 +490,14 @@ describe('cross-chain selector fallback decode', () => {
       accumulatedSim: receiverSim,
     };
 
+    BlockExplorerFactory.fetchContractAbi = async (target) => {
+      const address = getAddress(target);
+      if (address === receiverAddress) return forwardAbi;
+      if (address === firstTarget) return ownerAbi;
+      if (address === secondTarget) return feeAbi;
+      return null;
+    };
+
     try {
       await generateAndSaveReports({
         governorType: 'bravo',
@@ -375,6 +524,7 @@ describe('cross-chain selector fallback decode', () => {
       expect(steps[1]?.status).toBe('success');
       expect(steps[1]?.forwardedCall?.signature).toBe('setFeeTo(address)');
     } finally {
+      BlockExplorerFactory.fetchContractAbi = originalFetchContractAbi;
       rmSync(outputDir, { recursive: true, force: true });
     }
   }, 60000);


### PR DESCRIPTION
## Summary
- render every cross-chain destination step in Overview
- show each destination target in the Calls tab instead of summarizing with `steps[0]`
- expand Polygon Fx batch previews so inner calls are visible in generated reports

## Test
- `bun test tests/cross-chain-selector-fallback.test.ts frontend/src/components/structured-report/CrossChainPreview.test.tsx frontend/src/components/CallGroupedView.test.tsx frontend/src/components/structured-report/cross-chain.test.ts`
- `bun run check`
- `cd frontend && bun run check`
- `bun run contract:check`
- `cd checks && bun test`
- `node --no-experimental-webstorage node_modules/.bin/next build`
