### PR TITLE
fix: validate LayerZero receiver trusted remotes

### DIFF
--- a/checks/tests/cross-chain-execution-engine.test.ts
+++ b/checks/tests/cross-chain-execution-engine.test.ts
@@ -9,6 +9,7 @@ import {
   parseAbi,
 } from 'viem';
 import { bsc, celo, mainnet, monad, polygon, tempo } from 'viem/chains';
+import { config as layerZeroReceiverAuthTestConfig } from '../../sims/layerzero-receiver-auth-test.sim';
 import type { TenderlySimulation } from '../../types.d';
 import {
   LAYER_ZERO_EXECUTE_ABI,
@@ -54,12 +55,33 @@ if (!CELO_WORMHOLE_CORE || !MONAD_WORMHOLE_CORE) {
   throw new Error('Expected Celo and Monad Wormhole core addresses to be configured');
 }
 
-type ReceiverReadRequest = { address: `0x${string}`; functionName: string; blockNumber?: bigint };
+type ReceiverReadRequest = {
+  address: `0x${string}`;
+  functionName: string;
+  args?: readonly unknown[];
+  blockNumber?: bigint;
+};
+
+function makeLayerZeroTrustedRemotePath(
+  remoteAddress: `0x${string}`,
+  localAddress: `0x${string}`,
+): Hex {
+  return `${getAddress(remoteAddress)}${getAddress(localAddress).slice(2)}` as Hex;
+}
 
 async function resolveMockedReceiverReadContract(
   request: ReceiverReadRequest,
 ): Promise<Hex | bigint> {
   const receiverAddress = getAddress(request.address);
+
+  if (
+    request.functionName === 'trustedRemoteLookup' &&
+    (receiverAddress === UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR ||
+      receiverAddress === UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR)
+  ) {
+    expect(request.args).toEqual([101]);
+    return makeLayerZeroTrustedRemotePath(UNISWAP_OMNICHAIN_PROPOSAL_SENDER, receiverAddress);
+  }
 
   if (
     receiverAddress === getAddress(TEMPO_RECEIVER) ||
@@ -196,6 +218,7 @@ mock.module('../../utils/clients/tenderly-api', () => ({
 
 const WORMHOLE_PROPOSAL_TARGET = '0xf5F4496219F31CDCBa6130B5402873624585615a' as const;
 const WORMHOLE_ADDRESS = '0x00000000000000000000000000000000000000AA' as const;
+const BAD_LAYER_ZERO_REMOTE = getAddress('0x000000000000000000000000000000000000dEaD');
 const DIRECT_DESTINATION_CHAIN_ID = polygon.id;
 const CELO_CHAIN_ID = celo.id;
 const TIMELOCK_ADDRESS = '0x1a9C8182C09F50C8318d769245beA52c32BE35BC';
@@ -338,14 +361,11 @@ function makeLayerZeroTrustedRemoteCalldata(
   laneKey: keyof typeof LAYER_ZERO_LANE_SUPPORT_MATRIX,
 ): `0x${string}` {
   const lane = LAYER_ZERO_LANE_SUPPORT_MATRIX[laneKey];
-  if (!lane.requiredTrustedRemoteAddress) {
-    throw new Error(`LayerZero lane ${laneKey} does not require trusted remote setup`);
-  }
 
   return encodeFunctionData({
     abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
     functionName: 'setTrustedRemoteAddress',
-    args: [lane.layerZeroRemoteChainId, lane.requiredTrustedRemoteAddress],
+    args: [lane.layerZeroRemoteChainId, lane.l2FromAddress],
   });
 }
 
@@ -474,6 +494,19 @@ describe('cross-chain destination execution engine', () => {
       }),
     );
 
+    const trustedRemoteReads = mockedReceiverReadContract.mock.calls
+      .map(([request]) => request)
+      .filter((request) => request.functionName === 'trustedRemoteLookup');
+    expect(trustedRemoteReads).toEqual([
+      expect.objectContaining({
+        address: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+        args: [101],
+      }),
+      expect.objectContaining({
+        address: UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR,
+        args: [101],
+      }),
+    ]);
     expect(mockedSendSimulation).toHaveBeenCalledTimes(3);
     expect(transportCalls[0]).toMatchObject({
       network_id: `${LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId}`,
@@ -502,6 +535,104 @@ describe('cross-chain destination execution engine', () => {
     ]);
     expect(result.destinationJobResults.map((job) => job.stepResults.length)).toEqual([2, 1]);
     expect(result.destinationJobResults.map((job) => job.status)).toEqual(['success', 'success']);
+  });
+
+  test('executes the receiver-auth LayerZero sim fixture when receiver trusts expected remote', async () => {
+    const target = getAddress('0x00000000000000000000000000000000000000A1');
+
+    enqueueSimulation(
+      makeSimulation({
+        id: 'layerzero-receiver-auth-step',
+        chainId: LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId,
+      }),
+    );
+
+    const result = await handleCrossChainSimulations(
+      makeSourceResult(layerZeroReceiverAuthTestConfig.calldatas, {
+        targets: layerZeroReceiverAuthTestConfig.targets,
+      }),
+    );
+
+    expect(mockedSendSimulation).toHaveBeenCalledTimes(1);
+    expect(transportCalls[0]).toMatchObject({
+      network_id: `${LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId}`,
+      from: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+      to: target,
+      input: '0x12345678',
+      value: '0',
+    });
+    expect(result.destinationJobResults).toHaveLength(1);
+    expect(result.destinationJobResults[0]?.bridgeType).toBe('LayerZeroL1L2');
+    expect(result.destinationJobResults[0]?.status).toBe('success');
+    expect(result.crossChainFailure).toBe(false);
+  });
+
+  test('fails LayerZero destination job before simulation when receiver trusts wrong remote', async () => {
+    mockedReceiverReadContract.mockImplementation(async (request) => {
+      if (request.functionName === 'trustedRemoteLookup') {
+        expect(request.args).toEqual([101]);
+        return makeLayerZeroTrustedRemotePath(BAD_LAYER_ZERO_REMOTE, getAddress(request.address));
+      }
+
+      return resolveMockedReceiverReadContract(request);
+    });
+
+    const result = await handleCrossChainSimulations(
+      makeSourceResult(layerZeroReceiverAuthTestConfig.calldatas, {
+        targets: layerZeroReceiverAuthTestConfig.targets,
+      }),
+    );
+
+    expect(mockedSendSimulation).not.toHaveBeenCalled();
+    expect(result.destinationJobResults).toHaveLength(1);
+    expect(result.destinationJobResults[0]?.bridgeType).toBe('LayerZeroL1L2');
+    expect(result.destinationJobResults[0]?.status).toBe('failure');
+    expect(result.destinationJobResults[0]?.stepResults).toHaveLength(0);
+    expect(result.destinationJobResults[0]?.error).toContain('trusted remote mismatch');
+    expect(result.crossChainFailure).toBe(true);
+  });
+
+  test('fails LayerZero destination job when prior state already touched receiver storage', async () => {
+    const secondTarget = getAddress('0x00000000000000000000000000000000000000A2');
+    const firstCalldata = makeLayerZeroCalldata('megaeth', [
+      {
+        target: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+        data: '0x11111111',
+      },
+    ]);
+    const secondCalldata = makeLayerZeroCalldata('megaeth', [
+      { target: secondTarget, data: '0x22222222' },
+    ]);
+
+    enqueueSimulation(
+      makeSimulation({
+        id: 'layerzero-receiver-storage-step',
+        chainId: LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId,
+        stateDiff: [
+          {
+            address: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+            key: '0x01',
+            dirty: '0xaa',
+          },
+        ],
+      }),
+    );
+
+    const result = await handleCrossChainSimulations(
+      makeSourceResult([firstCalldata, secondCalldata], {
+        targets: [UNISWAP_OMNICHAIN_PROPOSAL_SENDER, UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
+      }),
+    );
+
+    expect(mockedSendSimulation).toHaveBeenCalledTimes(1);
+    expect(result.destinationJobResults).toHaveLength(2);
+    expect(result.destinationJobResults[0]?.status).toBe('success');
+    expect(result.destinationJobResults[1]?.status).toBe('failure');
+    expect(result.destinationJobResults[1]?.stepResults).toHaveLength(0);
+    expect(result.destinationJobResults[1]?.error).toContain(
+      'destination state overrides already modify 1 receiver storage slot',
+    );
+    expect(result.crossChainFailure).toBe(true);
   });
 
   test('executes one simulated destination job per supported Wormhole lane', async () => {

--- a/docs/CROSS_CHAIN.md
+++ b/docs/CROSS_CHAIN.md
@@ -69,11 +69,11 @@ Wormhole support is defined centrally by the support matrix in [wormhole-support
 
 - Source bridge call: Uniswap `OmnichainProposalSender.execute(uint16,bytes,bytes)`
 - Address model: destination execution uses the configured remote `OmnichainGovernanceExecutor`
-- Main job: decode the LayerZero executor payload and simulate the destination calls directly
+- Main job: decode the LayerZero executor payload, verify the destination receiver trusted-remote config, and simulate the destination calls
 
 LayerZero support exists for migration proposals that still use the old LayerZero path to update remote governance configuration. Future proposals that call Wormhole directly should use `WormholeL1L2`.
 
-The supplied Uniswap `OmnichainProposalSender` has a confirmed trusted remote for Avalanche LayerZero V1 endpoint id `106`. MegaETH uses LayerZero V1 endpoint id `398`, but that id is not configured on the supplied Ethereum sender until the migration proposal calls `setTrustedRemoteAddress(398, 0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c)`. Seatbelt only treats a MegaETH LayerZero `execute` call as supported when that trusted-remote setup call appears earlier in the same proposal.
+Seatbelt simulates the Ethereum proposal normally, so source-side calls such as `setTrustedRemoteAddress(...)` are covered by the source simulation. Before replaying decoded destination calls, Seatbelt also reads the destination receiver's `trustedRemoteLookup(101)` entry and verifies it points back to the expected Uniswap mainnet sender. This means MegaETH does not need to configure the trusted remote in every proposal, but a bad or missing destination receiver config blocks the destination job before the inner calls are simulated.
 
 ## Wormhole Support Model
 

--- a/sims/layerzero-receiver-auth-test.sim.ts
+++ b/sims/layerzero-receiver-auth-test.sim.ts
@@ -1,0 +1,43 @@
+import { encodeAbiParameters, encodeFunctionData, getAddress } from 'viem';
+import type { SimulationConfigNew } from '../types';
+import {
+  LAYER_ZERO_EXECUTE_ABI,
+  LAYER_ZERO_LANE_SUPPORT_MATRIX,
+  LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
+  UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+  UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+} from '../utils/bridges/layerzero';
+
+const TEST_DESTINATION_TARGET = getAddress('0x00000000000000000000000000000000000000A1');
+const MEGAETH_LANE = LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth;
+
+const setupCalldata = encodeFunctionData({
+  abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
+  functionName: 'setTrustedRemoteAddress',
+  args: [MEGAETH_LANE.layerZeroRemoteChainId, UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR],
+});
+
+const destinationPayload = encodeAbiParameters(
+  [{ type: 'address[]' }, { type: 'uint256[]' }, { type: 'bytes[]' }],
+  [[TEST_DESTINATION_TARGET], [0n], ['0x12345678']],
+);
+
+const executeCalldata = encodeFunctionData({
+  abi: LAYER_ZERO_EXECUTE_ABI,
+  functionName: 'execute',
+  args: [MEGAETH_LANE.layerZeroRemoteChainId, destinationPayload, '0x'],
+});
+
+export const config: SimulationConfigNew = {
+  type: 'new',
+  daoName: 'Uniswap',
+  governorType: 'bravo',
+  governorAddress: getAddress('0x408ED6354d4973f66138C91495F2f2FCbd8724C3'),
+  targets: [UNISWAP_OMNICHAIN_PROPOSAL_SENDER, UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
+  values: [0n, 0n],
+  signatures: ['', ''],
+  calldatas: [setupCalldata, executeCalldata],
+  description: `# LayerZero receiver auth test
+
+Minimal Uniswap-style LayerZero proposal used to verify Seatbelt checks destination receiver trusted-remote config before replaying destination calls. The setup call configures the source sender for the live source simulation; Seatbelt validates the destination receiver separately.`,
+};

--- a/tests/layerzero-execution.test.ts
+++ b/tests/layerzero-execution.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { type Hex, getAddress } from 'viem';
+import {
+  UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+  UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+} from '../utils/bridges/layerzero';
+import { layerZeroTrustedRemoteMatches } from '../utils/bridges/layerzero-execution';
+
+const WRONG_REMOTE = getAddress('0x000000000000000000000000000000000000dEaD');
+const WRONG_LOCAL = getAddress('0x000000000000000000000000000000000000bEEF');
+
+function trustedRemotePath(remoteAddress: `0x${string}`, localAddress: `0x${string}`): Hex {
+  return `${getAddress(remoteAddress)}${getAddress(localAddress).slice(2)}` as Hex;
+}
+
+describe('LayerZero receiver execution checks', () => {
+  test('accepts a trusted remote path for the expected source and local receiver', () => {
+    expect(
+      layerZeroTrustedRemoteMatches(
+        trustedRemotePath(
+          UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+          UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+        ),
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects the wrong source remote address', () => {
+    expect(
+      layerZeroTrustedRemoteMatches(
+        trustedRemotePath(WRONG_REMOTE, UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR),
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+      ),
+    ).toBe(false);
+  });
+
+  test('rejects the wrong local receiver address', () => {
+    expect(
+      layerZeroTrustedRemoteMatches(
+        trustedRemotePath(UNISWAP_OMNICHAIN_PROPOSAL_SENDER, WRONG_LOCAL),
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+      ),
+    ).toBe(false);
+  });
+
+  test('rejects unset trusted remote bytes', () => {
+    expect(
+      layerZeroTrustedRemoteMatches(
+        '0x',
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/layerzero-parser.test.ts
+++ b/tests/layerzero-parser.test.ts
@@ -9,9 +9,9 @@ import {
 } from 'viem';
 import { config as migrationDraftConfig } from '../sims/layerzero-wormhole-migration-test.sim';
 import {
+  LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID,
   LAYER_ZERO_EXECUTE_ABI,
   LAYER_ZERO_LANE_SUPPORT_MATRIX,
-  LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
   UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
   UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR,
   UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
@@ -26,14 +26,6 @@ function buildLayerZeroExecuteCalldata(remoteChainId: number, payload: Hex): Hex
     abi: LAYER_ZERO_EXECUTE_ABI,
     functionName: 'execute',
     args: [remoteChainId, payload, '0x'],
-  });
-}
-
-function buildLayerZeroTrustedRemoteCalldata(remoteChainId: number, remoteAddress: Hex): Hex {
-  return encodeFunctionData({
-    abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
-    functionName: 'setTrustedRemoteAddress',
-    args: [remoteChainId, remoteAddress],
   });
 }
 
@@ -84,7 +76,7 @@ describe('LayerZero proposal parser', () => {
     ]);
   });
 
-  test('extracts MegaETH destination calls after trusted remote setup', () => {
+  test('extracts MegaETH destination calls without requiring same-proposal trusted remote setup', () => {
     const firstTarget = getAddress('0x00000000000000000000000000000000000000c1');
     const secondTarget = getAddress('0x00000000000000000000000000000000000000c2');
     const firstCalldata = encodeFunctionData({
@@ -104,20 +96,16 @@ describe('LayerZero proposal parser', () => {
         { target: secondTarget, calldata: secondCalldata },
       ]),
     );
-    const setupCalldata = buildLayerZeroTrustedRemoteCalldata(
-      LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.layerZeroRemoteChainId,
-      UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
-    );
 
     const jobs = extractLayerZeroL1L2JobsFromProposal(
-      [UNISWAP_OMNICHAIN_PROPOSAL_SENDER, UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
-      [setupCalldata, executeCalldata],
+      [UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
+      [executeCalldata],
     );
 
     expect(jobs).toHaveLength(1);
     expect(jobs[0]?.destinationChainId).toBe(MEGAETH_CHAIN_ID);
     expect(jobs[0]?.l2FromAddress).toBe(UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR);
-    expect(jobs[0]?.sourceOrder).toBe(1);
+    expect(jobs[0]?.sourceOrder).toBe(0);
     expect(jobs[0]?.calls).toEqual([
       {
         l2TargetAddress: firstTarget,
@@ -150,7 +138,7 @@ describe('LayerZero proposal parser', () => {
     ]);
   });
 
-  test('requires MegaETH trusted remote setup before execute', () => {
+  test('attaches LayerZero receiver trusted remote metadata to destination jobs', () => {
     const payload = buildExecutorPayload([
       {
         target: getAddress('0x00000000000000000000000000000000000000c1'),
@@ -162,9 +150,16 @@ describe('LayerZero proposal parser', () => {
       payload,
     );
 
-    expect(() =>
-      extractLayerZeroL1L2JobsFromProposal([UNISWAP_OMNICHAIN_PROPOSAL_SENDER], [executeCalldata]),
-    ).toThrow('requires setTrustedRemoteAddress before execute');
+    const jobs = extractLayerZeroL1L2JobsFromProposal(
+      [UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
+      [executeCalldata],
+    );
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.layerZeroTrustedRemote).toEqual({
+      sourceRemoteChainId: LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID,
+      expectedRemoteAddress: UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+    });
   });
 
   test('supports GovernorBravo-style payloads with signatures plus argument bytes', () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -289,6 +289,10 @@ export interface CrossChainExecutionJob {
   destinationChainId: number;
   l2FromAddress: Address;
   wormholeChainId?: number;
+  layerZeroTrustedRemote?: {
+    sourceRemoteChainId: number;
+    expectedRemoteAddress: Address;
+  };
   sourceOrder: number;
   calls: CrossChainExecutionCall[];
 }

--- a/utils/bridges/adapter.ts
+++ b/utils/bridges/adapter.ts
@@ -4,6 +4,7 @@ import type { WormholeReceiverRuntimeStateByKey } from '../cross-chain/wormhole-
 import type { SimulationStateObjects } from '../derived-state';
 import { extractArbitrumL1L2JobsFromProposal } from './arbitrum';
 import { extractLayerZeroL1L2JobsFromProposal } from './layerzero';
+import { prepareLayerZeroExecution } from './layerzero-execution';
 import { extractOptimismL1L2JobsFromProposal } from './optimism';
 import { extractPolygonFxL1L2JobsFromProposal } from './polygon-fx';
 import { extractWormholeExecutionJobsFromProposal } from './wormhole';
@@ -79,6 +80,7 @@ const CROSS_CHAIN_BRIDGE_ADAPTERS: readonly CrossChainBridgeAdapter[] = [
     bridgeType: 'LayerZeroL1L2',
     extractJobs: ({ targets, calldatas }) =>
       extractLayerZeroL1L2JobsFromProposal(targets, calldatas),
+    prepareExecution: prepareLayerZeroExecution,
   },
 ] as const;
 

--- a/utils/bridges/layerzero-execution.ts
+++ b/utils/bridges/layerzero-execution.ts
@@ -1,0 +1,115 @@
+import { type Address, type Hex, getAddress, isHex } from 'viem';
+import { getClientForChain } from '../clients/client';
+import type {
+  CrossChainBridgeExecutionContext,
+  CrossChainBridgePreparedExecution,
+} from './adapter';
+import { LAYER_ZERO_TRUSTED_REMOTE_LOOKUP_ABI } from './layerzero';
+
+const ADDRESS_BYTE_LENGTH = 20;
+const HEX_PREFIX_LENGTH = 2;
+const ADDRESS_HEX_LENGTH = ADDRESS_BYTE_LENGTH * 2;
+const ADDRESS_LENGTH = HEX_PREFIX_LENGTH + ADDRESS_HEX_LENGTH;
+const TRUSTED_REMOTE_PATH_LENGTH = HEX_PREFIX_LENGTH + ADDRESS_HEX_LENGTH * 2;
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function readPackedAddress(value: Hex, byteOffset: number): Address | null {
+  const start = HEX_PREFIX_LENGTH + byteOffset * 2;
+  const end = start + ADDRESS_HEX_LENGTH;
+  if (value.length < end) return null;
+
+  const address = `0x${value.slice(start, end)}`;
+  if (!isHex(address) || address.length !== ADDRESS_LENGTH) return null;
+
+  try {
+    return getAddress(address);
+  } catch {
+    return null;
+  }
+}
+
+function formatTrustedRemote(value: Hex): string {
+  if (value === '0x') return 'unset';
+
+  const remote = readPackedAddress(value, 0);
+  const local = value.length >= TRUSTED_REMOTE_PATH_LENGTH ? readPackedAddress(value, 20) : null;
+
+  if (remote && local && value.length === TRUSTED_REMOTE_PATH_LENGTH) {
+    return `${remote} -> ${local}`;
+  }
+
+  return value;
+}
+
+export function layerZeroTrustedRemoteMatches(
+  configuredTrustedRemote: Hex,
+  expectedRemoteAddress: Address,
+  receiverAddress: Address,
+): boolean {
+  const expectedRemote = getAddress(expectedRemoteAddress);
+  const expectedLocal = getAddress(receiverAddress);
+
+  return (
+    configuredTrustedRemote.length === TRUSTED_REMOTE_PATH_LENGTH &&
+    readPackedAddress(configuredTrustedRemote, 0) === expectedRemote &&
+    readPackedAddress(configuredTrustedRemote, 20) === expectedLocal
+  );
+}
+
+export async function prepareLayerZeroExecution(
+  context: CrossChainBridgeExecutionContext,
+): Promise<CrossChainBridgePreparedExecution> {
+  const trustedRemote = context.job.layerZeroTrustedRemote;
+  if (!trustedRemote) {
+    throw new Error('LayerZero destination job is missing trusted remote metadata');
+  }
+
+  const client = getClientForChain(context.job.destinationChainId);
+  const receiverAddress = context.job.l2FromAddress;
+  const receiverState = context.workingState?.[getAddress(receiverAddress)];
+  const receiverStorageOverrideCount = Object.keys(receiverState?.storage ?? {}).length;
+  if (receiverStorageOverrideCount > 0) {
+    throw new Error(
+      `LayerZero receiver trusted remote read is ambiguous for chain ${context.job.destinationChainId}, receiver ${receiverAddress}: destination state overrides already modify ${receiverStorageOverrideCount} receiver storage slot(s), so Seatbelt cannot validate trustedRemoteLookup(${trustedRemote.sourceRemoteChainId}) against live RPC state`,
+    );
+  }
+
+  let configuredTrustedRemote: Hex;
+
+  try {
+    const result = await client.readContract({
+      address: receiverAddress,
+      abi: LAYER_ZERO_TRUSTED_REMOTE_LOOKUP_ABI,
+      functionName: 'trustedRemoteLookup',
+      args: [trustedRemote.sourceRemoteChainId],
+    });
+
+    if (typeof result !== 'string' || !isHex(result)) {
+      throw new Error(`invalid trustedRemoteLookup result ${String(result)}`);
+    }
+
+    configuredTrustedRemote = result;
+  } catch (error) {
+    throw new Error(
+      `LayerZero receiver trusted remote read failed for chain ${context.job.destinationChainId}, receiver ${receiverAddress}, source remote chain ${trustedRemote.sourceRemoteChainId}: ${getErrorMessage(error)}`,
+    );
+  }
+
+  if (
+    !layerZeroTrustedRemoteMatches(
+      configuredTrustedRemote,
+      trustedRemote.expectedRemoteAddress,
+      receiverAddress,
+    )
+  ) {
+    throw new Error(
+      `LayerZero receiver trusted remote mismatch for chain ${context.job.destinationChainId}: receiver ${receiverAddress} trusts ${formatTrustedRemote(configuredTrustedRemote)} for source remote chain ${trustedRemote.sourceRemoteChainId}, expected ${trustedRemote.expectedRemoteAddress}`,
+    );
+  }
+
+  return { calls: context.job.calls };
+}

--- a/utils/bridges/layerzero.ts
+++ b/utils/bridges/layerzero.ts
@@ -10,7 +10,7 @@ import {
 } from 'viem';
 import { avalanche } from 'viem/chains';
 import type { CrossChainExecutionCall, CrossChainExecutionJob } from '../../types.d';
-import { MEGAETH_CHAIN_ID, MEGAETH_CHAIN_NAME } from '../chains/megaeth';
+import { MEGAETH_CHAIN_ID } from '../chains/megaeth';
 
 export const LAYER_ZERO_EXECUTE_ABI = parseAbi([
   'function execute(uint16 remoteChainId, bytes payload, bytes adapterParams)',
@@ -20,12 +20,14 @@ export const LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI = parseAbi([
   'function setTrustedRemoteAddress(uint16 remoteChainId, bytes remoteAddress)',
 ]);
 
+export const LAYER_ZERO_TRUSTED_REMOTE_LOOKUP_ABI = parseAbi([
+  'function trustedRemoteLookup(uint16 remoteChainId) view returns (bytes)',
+]);
+
 const LAYER_ZERO_EXECUTE_SELECTOR = toFunctionSelector(
   'function execute(uint16 remoteChainId, bytes payload, bytes adapterParams)',
 );
-const LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_SELECTOR = toFunctionSelector(
-  'function setTrustedRemoteAddress(uint16 remoteChainId, bytes remoteAddress)',
-);
+export const LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID = 101;
 
 export const UNISWAP_OMNICHAIN_PROPOSAL_SENDER = getAddress(
   '0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc',
@@ -37,47 +39,34 @@ export const UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR = getAddress(
   '0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c',
 );
 
-export type LayerZeroLaneKey = 'avalanche' | 'megaeth';
+type LayerZeroLaneKey = 'avalanche' | 'megaeth';
 
-export type LayerZeroLaneSupport = {
-  key: LayerZeroLaneKey;
-  chainName: string;
+type LayerZeroLaneSupport = {
   destinationChainId: number;
   layerZeroRemoteChainId: number;
   l2FromAddress: `0x${string}`;
-  senderTargets: readonly `0x${string}`[];
-  requiredTrustedRemoteAddress?: `0x${string}`;
+  senderTarget: `0x${string}`;
 };
 
 export const LAYER_ZERO_LANE_SUPPORT_MATRIX: Record<LayerZeroLaneKey, LayerZeroLaneSupport> = {
   avalanche: {
-    key: 'avalanche',
-    chainName: 'Avalanche',
     destinationChainId: avalanche.id,
     layerZeroRemoteChainId: 106,
     l2FromAddress: UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR,
-    senderTargets: [UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
+    senderTarget: UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
   },
   megaeth: {
-    key: 'megaeth',
-    chainName: MEGAETH_CHAIN_NAME,
     destinationChainId: MEGAETH_CHAIN_ID,
     layerZeroRemoteChainId: 398,
     l2FromAddress: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
-    senderTargets: [UNISWAP_OMNICHAIN_PROPOSAL_SENDER],
-    requiredTrustedRemoteAddress: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
+    senderTarget: UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
   },
 };
 
-export const SUPPORTED_LAYER_ZERO_LANE_KEYS = [
-  'avalanche',
-  'megaeth',
-] as const satisfies readonly LayerZeroLaneKey[];
+const SUPPORTED_LAYER_ZERO_LANES = Object.values(LAYER_ZERO_LANE_SUPPORT_MATRIX);
 
 const KNOWN_LAYER_ZERO_SENDER_TARGETS = new Set(
-  SUPPORTED_LAYER_ZERO_LANE_KEYS.flatMap(
-    (laneKey) => LAYER_ZERO_LANE_SUPPORT_MATRIX[laneKey].senderTargets,
-  ).map((target) => target.toLowerCase()),
+  SUPPORTED_LAYER_ZERO_LANES.map((lane) => lane.senderTarget.toLowerCase()),
 );
 
 type DecodedLayerZeroPayload = {
@@ -92,9 +81,7 @@ type LayerZeroPayloadDecodeResult =
   | { kind: 'malformed' };
 
 function getLayerZeroLaneByRemoteChainId(remoteChainId: number): LayerZeroLaneSupport | undefined {
-  return SUPPORTED_LAYER_ZERO_LANE_KEYS.map(
-    (laneKey) => LAYER_ZERO_LANE_SUPPORT_MATRIX[laneKey],
-  ).find((lane) => lane.layerZeroRemoteChainId === remoteChainId);
+  return SUPPORTED_LAYER_ZERO_LANES.find((lane) => lane.layerZeroRemoteChainId === remoteChainId);
 }
 
 function normalizeProposalTarget(target: string): string | null {
@@ -116,71 +103,6 @@ function isKnownLayerZeroProposalCall(target: string, data: string): boolean {
   }
 
   return slice(data, 0, 4) === LAYER_ZERO_EXECUTE_SELECTOR;
-}
-
-function decodePackedAddress(value: Hex): `0x${string}` | null {
-  if (value.length !== 42) return null;
-
-  try {
-    return getAddress(value);
-  } catch {
-    return null;
-  }
-}
-
-function isTrustedRemoteSetupCall(
-  target: string,
-  data: string,
-  lane: LayerZeroLaneSupport,
-): boolean {
-  if (!lane.requiredTrustedRemoteAddress || !isHex(data) || data.length < 10) {
-    return false;
-  }
-
-  const normalizedTarget = normalizeProposalTarget(target);
-  if (
-    !normalizedTarget ||
-    !lane.senderTargets.some((senderTarget) => senderTarget.toLowerCase() === normalizedTarget)
-  ) {
-    return false;
-  }
-
-  if (slice(data, 0, 4) !== LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_SELECTOR) {
-    return false;
-  }
-
-  try {
-    const decoded = decodeFunctionData({
-      abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
-      data,
-    });
-    if (decoded.functionName !== 'setTrustedRemoteAddress') return false;
-
-    const [remoteChainId, remoteAddress] = decoded.args;
-    const decodedRemoteAddress = decodePackedAddress(remoteAddress);
-
-    return (
-      lane.layerZeroRemoteChainId === Number(remoteChainId) &&
-      decodedRemoteAddress?.toLowerCase() === lane.requiredTrustedRemoteAddress.toLowerCase()
-    );
-  } catch {
-    return false;
-  }
-}
-
-function proposalConfiguresTrustedRemoteBeforeIndex(
-  targets: readonly string[],
-  calldatas: readonly string[],
-  index: number,
-  lane: LayerZeroLaneSupport,
-): boolean {
-  for (let i = 0; i < index; i += 1) {
-    const target = targets[i];
-    const data = calldatas[i];
-    if (target && data && isTrustedRemoteSetupCall(target, data, lane)) return true;
-  }
-
-  return false;
 }
 
 function decodeLayerZeroExecutorPayload(payload: Hex): LayerZeroPayloadDecodeResult {
@@ -283,15 +205,6 @@ export function extractLayerZeroL1L2JobsFromProposal(
         `Unsupported LayerZero remote chain id ${resolvedRemoteChainId} in proposal calldata index ${i}`,
       );
     }
-    if (
-      lane.requiredTrustedRemoteAddress &&
-      !proposalConfiguresTrustedRemoteBeforeIndex(targets, calldatas, i, lane)
-    ) {
-      throw new Error(
-        `LayerZero remote chain id ${resolvedRemoteChainId} requires setTrustedRemoteAddress before execute in proposal calldata index ${i}`,
-      );
-    }
-
     const decodedPayload = decodeLayerZeroExecutorPayload(payload);
     if (decodedPayload.kind !== 'supported') {
       throw new Error(
@@ -309,6 +222,10 @@ export function extractLayerZeroL1L2JobsFromProposal(
       bridgeType: 'LayerZeroL1L2',
       destinationChainId: lane.destinationChainId,
       l2FromAddress: lane.l2FromAddress,
+      layerZeroTrustedRemote: {
+        sourceRemoteChainId: LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID,
+        expectedRemoteAddress: lane.senderTarget,
+      },
       sourceOrder: i,
       calls,
     });


### PR DESCRIPTION
## Summary
- Validate LayerZero destination receiver trusted-remote config before replaying destination calls.
- Fail closed when prior destination state touched receiver storage, instead of validating against stale live RPC state.
- Add receiver-auth tests and docs for the LayerZero mental model.

## Test Plan
- Automated: `bun test tests/layerzero-parser.test.ts tests/layerzero-execution.test.ts checks/tests/cross-chain-execution-engine.test.ts` — covers parser behavior, receiver-auth matching, bad sender rejection, and cross-chain execution.
- Automated: `bun run typecheck` — verifies TypeScript types.
- Automated: `bunx biome check utils/bridges/layerzero.ts utils/bridges/layerzero-execution.ts utils/bridges/adapter.ts types.d.ts tests/layerzero-parser.test.ts tests/layerzero-execution.test.ts checks/tests/cross-chain-execution-engine.test.ts sims/layerzero-receiver-auth-test.sim.ts docs/CROSS_CHAIN.md` — verifies formatting and lint rules.
- Automated: `git diff --check` — verifies no whitespace errors.
- Manual: `SIM_NAME=layerzero-wormhole-migration-test bun start` with repo-root `.env` — original LayerZero migration sim completed; MegaETH and Avalanche LayerZero jobs were both successful with 3/3 destination steps.