### PR TITLE
fix: track LayerZero receiver changes

### DIFF
--- a/checks/tests/cross-chain-execution-engine.test.ts
+++ b/checks/tests/cross-chain-execution-engine.test.ts
@@ -48,6 +48,7 @@ const TEMPO_RECEIVER = getWormholeLaneByKey('tempo').l2FromAddress;
 const CELO_RECEIVER = getWormholeLaneByKey('celo').l2FromAddress;
 const MONAD_RECEIVER = getWormholeLaneByKey('monad').l2FromAddress;
 const BNB_RECEIVER = getWormholeLaneByKey('bnb').l2FromAddress;
+const SECOND_MEGAETH_LAYER_ZERO_RECEIVER = getAddress('0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9');
 const CELO_WORMHOLE_CORE = getWormholeLaneByKey('celo').wormholeReceiverCoreAddress;
 const MONAD_WORMHOLE_CORE = getWormholeLaneByKey('monad').wormholeReceiverCoreAddress;
 
@@ -77,6 +78,7 @@ async function resolveMockedReceiverReadContract(
   if (
     request.functionName === 'trustedRemoteLookup' &&
     (receiverAddress === UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR ||
+      receiverAddress === SECOND_MEGAETH_LAYER_ZERO_RECEIVER ||
       receiverAddress === UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR)
   ) {
     expect(request.args).toEqual([101]);
@@ -359,13 +361,14 @@ function makeLayerZeroCalldata(
 
 function makeLayerZeroTrustedRemoteCalldata(
   laneKey: keyof typeof LAYER_ZERO_LANE_SUPPORT_MATRIX,
+  receiver?: `0x${string}`,
 ): `0x${string}` {
   const lane = LAYER_ZERO_LANE_SUPPORT_MATRIX[laneKey];
 
   return encodeFunctionData({
     abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
     functionName: 'setTrustedRemoteAddress',
-    args: [lane.layerZeroRemoteChainId, lane.l2FromAddress],
+    args: [lane.layerZeroRemoteChainId, receiver ?? lane.l2FromAddress],
   });
 }
 
@@ -452,17 +455,25 @@ describe('cross-chain destination execution engine', () => {
     expect(result.destinationJobResults[0]?.status).toBe('success');
   });
 
-  test('executes LayerZero migration payloads on MegaETH and Avalanche after MegaETH setup', async () => {
+  test('executes LayerZero migration payloads after in-proposal receiver changes', async () => {
     const avalancheTarget = getAddress('0x0000000000000000000000000000000000000a60');
     const firstMegaethTarget = getAddress('0x0000000000000000000000000000000000000a61');
     const secondMegaethTarget = getAddress('0x0000000000000000000000000000000000000a62');
+    const thirdMegaethTarget = getAddress('0x0000000000000000000000000000000000000a63');
     const megaethSetupCalldata = makeLayerZeroTrustedRemoteCalldata('megaeth');
+    const secondMegaethSetupCalldata = makeLayerZeroTrustedRemoteCalldata(
+      'megaeth',
+      SECOND_MEGAETH_LAYER_ZERO_RECEIVER,
+    );
     const avalancheCalldata = makeLayerZeroCalldata('avalanche', [
       { target: avalancheTarget, data: '0x11111111' },
     ]);
     const megaethCalldata = makeLayerZeroCalldata('megaeth', [
       { target: firstMegaethTarget, value: 3n, data: '0x22222222' },
       { target: secondMegaethTarget, value: 0n, data: '0x33333333' },
+    ]);
+    const secondReceiverMegaethCalldata = makeLayerZeroCalldata('megaeth', [
+      { target: thirdMegaethTarget, data: '0x44444444' },
     ]);
 
     enqueueSimulation(
@@ -483,15 +494,32 @@ describe('cross-chain destination execution engine', () => {
         chainId: LAYER_ZERO_LANE_SUPPORT_MATRIX.avalanche.destinationChainId,
       }),
     );
+    enqueueSimulation(
+      makeSimulation({
+        id: 'layerzero-megaeth-second-receiver-step',
+        chainId: LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId,
+      }),
+    );
 
     const result = await handleCrossChainSimulations(
-      makeSourceResult([megaethSetupCalldata, megaethCalldata, avalancheCalldata], {
-        targets: [
-          UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
-          UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
-          UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+      makeSourceResult(
+        [
+          megaethSetupCalldata,
+          megaethCalldata,
+          avalancheCalldata,
+          secondMegaethSetupCalldata,
+          secondReceiverMegaethCalldata,
         ],
-      }),
+        {
+          targets: [
+            UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+            UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+            UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+            UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+            UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+          ],
+        },
+      ),
     );
 
     const trustedRemoteReads = mockedReceiverReadContract.mock.calls
@@ -506,8 +534,12 @@ describe('cross-chain destination execution engine', () => {
         address: UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR,
         args: [101],
       }),
+      expect.objectContaining({
+        address: SECOND_MEGAETH_LAYER_ZERO_RECEIVER,
+        args: [101],
+      }),
     ]);
-    expect(mockedSendSimulation).toHaveBeenCalledTimes(3);
+    expect(mockedSendSimulation).toHaveBeenCalledTimes(4);
     expect(transportCalls[0]).toMatchObject({
       network_id: `${LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId}`,
       from: UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
@@ -529,12 +561,24 @@ describe('cross-chain destination execution engine', () => {
       input: '0x11111111',
       value: '0',
     });
+    expect(transportCalls[3]).toMatchObject({
+      network_id: `${LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.destinationChainId}`,
+      from: SECOND_MEGAETH_LAYER_ZERO_RECEIVER,
+      to: thirdMegaethTarget,
+      input: '0x44444444',
+      value: '0',
+    });
     expect(result.destinationJobResults.map((job) => job.bridgeType)).toEqual([
       'LayerZeroL1L2',
       'LayerZeroL1L2',
+      'LayerZeroL1L2',
     ]);
-    expect(result.destinationJobResults.map((job) => job.stepResults.length)).toEqual([2, 1]);
-    expect(result.destinationJobResults.map((job) => job.status)).toEqual(['success', 'success']);
+    expect(result.destinationJobResults.map((job) => job.stepResults.length)).toEqual([2, 1, 1]);
+    expect(result.destinationJobResults.map((job) => job.status)).toEqual([
+      'success',
+      'success',
+      'success',
+    ]);
   });
 
   test('executes the receiver-auth LayerZero sim fixture when receiver trusts expected remote', async () => {

--- a/tests/layerzero-parser.test.ts
+++ b/tests/layerzero-parser.test.ts
@@ -3,6 +3,7 @@ import {
   type Hex,
   encodeAbiParameters,
   encodeFunctionData,
+  encodePacked,
   getAddress,
   parseAbi,
   toFunctionSelector,
@@ -12,6 +13,7 @@ import {
   LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID,
   LAYER_ZERO_EXECUTE_ABI,
   LAYER_ZERO_LANE_SUPPORT_MATRIX,
+  LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
   UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR,
   UNISWAP_OMNICHAIN_GOVERNANCE_EXECUTOR,
   UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
@@ -26,6 +28,17 @@ function buildLayerZeroExecuteCalldata(remoteChainId: number, payload: Hex): Hex
     abi: LAYER_ZERO_EXECUTE_ABI,
     functionName: 'execute',
     args: [remoteChainId, payload, '0x'],
+  });
+}
+
+function buildLayerZeroSetTrustedRemoteAddressCalldata(
+  remoteChainId: number,
+  receiver: `0x${string}`,
+): Hex {
+  return encodeFunctionData({
+    abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
+    functionName: 'setTrustedRemoteAddress',
+    args: [remoteChainId, encodePacked(['address'], [receiver])],
   });
 }
 
@@ -118,6 +131,42 @@ describe('LayerZero proposal parser', () => {
         l2Value: '0',
       },
     ]);
+  });
+
+  test('uses in-proposal trusted remote changes for subsequent MegaETH executes', () => {
+    const remoteChainId = LAYER_ZERO_LANE_SUPPORT_MATRIX.megaeth.layerZeroRemoteChainId;
+    const firstReceiver = UNISWAP_MEGAETH_OMNICHAIN_GOVERNANCE_EXECUTOR;
+    const secondReceiver = getAddress('0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9');
+    const firstTarget = getAddress('0x00000000000000000000000000000000000000c1');
+    const secondTarget = getAddress('0x00000000000000000000000000000000000000c2');
+    const firstCalldata = '0x12345678';
+    const secondCalldata = '0x87654321';
+
+    const jobs = extractLayerZeroL1L2JobsFromProposal(
+      [
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+        UNISWAP_OMNICHAIN_PROPOSAL_SENDER,
+      ],
+      [
+        buildLayerZeroSetTrustedRemoteAddressCalldata(remoteChainId, firstReceiver),
+        buildLayerZeroExecuteCalldata(
+          remoteChainId,
+          buildExecutorPayload([{ target: firstTarget, calldata: firstCalldata }]),
+        ),
+        buildLayerZeroSetTrustedRemoteAddressCalldata(remoteChainId, secondReceiver),
+        buildLayerZeroExecuteCalldata(
+          remoteChainId,
+          buildExecutorPayload([{ target: secondTarget, calldata: secondCalldata }]),
+        ),
+      ],
+    );
+
+    expect(jobs).toHaveLength(2);
+    expect(jobs.map((job) => job.sourceOrder)).toEqual([1, 3]);
+    expect(jobs.map((job) => job.l2FromAddress)).toEqual([firstReceiver, secondReceiver]);
+    expect(jobs.map((job) => job.calls[0]?.l2TargetAddress)).toEqual([firstTarget, secondTarget]);
   });
 
   test('extracts the supplied Uniswap migration draft calldata shape', () => {

--- a/utils/bridges/layerzero.ts
+++ b/utils/bridges/layerzero.ts
@@ -27,6 +27,9 @@ export const LAYER_ZERO_TRUSTED_REMOTE_LOOKUP_ABI = parseAbi([
 const LAYER_ZERO_EXECUTE_SELECTOR = toFunctionSelector(
   'function execute(uint16 remoteChainId, bytes payload, bytes adapterParams)',
 );
+const LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_SELECTOR = toFunctionSelector(
+  'function setTrustedRemoteAddress(uint16 remoteChainId, bytes remoteAddress)',
+);
 export const LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID = 101;
 
 export const UNISWAP_OMNICHAIN_PROPOSAL_SENDER = getAddress(
@@ -92,17 +95,27 @@ function normalizeProposalTarget(target: string): string | null {
   }
 }
 
-function isKnownLayerZeroProposalCall(target: string, data: string): boolean {
-  if (!isHex(data) || data === '0x' || data.length < 10) {
-    return false;
-  }
-
+function isKnownLayerZeroSenderTarget(target: string): boolean {
   const normalizedTarget = normalizeProposalTarget(target);
-  if (!normalizedTarget || !KNOWN_LAYER_ZERO_SENDER_TARGETS.has(normalizedTarget)) {
-    return false;
+  return normalizedTarget !== null && KNOWN_LAYER_ZERO_SENDER_TARGETS.has(normalizedTarget);
+}
+
+function getCalldataSelector(data: string): Hex | null {
+  if (!isHex(data) || data === '0x' || data.length < 10) {
+    return null;
   }
 
-  return slice(data, 0, 4) === LAYER_ZERO_EXECUTE_SELECTOR;
+  return slice(data, 0, 4);
+}
+
+function decodeLayerZeroRemoteAddress(remoteAddress: Hex, calldataIndex: number): `0x${string}` {
+  if (remoteAddress.length !== 42) {
+    throw new Error(
+      `LayerZero trusted remote address in proposal calldata index ${calldataIndex} must be a 20-byte address`,
+    );
+  }
+
+  return getAddress(remoteAddress);
 }
 
 function decodeLayerZeroExecutorPayload(payload: Hex): LayerZeroPayloadDecodeResult {
@@ -178,11 +191,40 @@ export function extractLayerZeroL1L2JobsFromProposal(
   calldatas: readonly string[],
 ): CrossChainExecutionJob[] {
   const jobs: CrossChainExecutionJob[] = [];
+  const activeReceiverByRemoteChainId = new Map<number, `0x${string}`>();
 
   for (let i = 0; i < Math.min(targets.length, calldatas.length); i += 1) {
     const target = targets[i];
     const data = calldatas[i];
-    if (!target || !isKnownLayerZeroProposalCall(target, data)) continue;
+    if (!target || !data || !isKnownLayerZeroSenderTarget(target)) continue;
+
+    const selector = getCalldataSelector(data);
+    if (selector === LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_SELECTOR) {
+      const decoded = (() => {
+        try {
+          return decodeFunctionData({
+            abi: LAYER_ZERO_SET_TRUSTED_REMOTE_ADDRESS_ABI,
+            data: data as Hex,
+          });
+        } catch {
+          throw new Error(
+            `Malformed LayerZero setTrustedRemoteAddress calldata in proposal calldata index ${i}`,
+          );
+        }
+      })();
+
+      const [remoteChainId, remoteAddress] = decoded.args;
+      const resolvedRemoteChainId = Number(remoteChainId);
+      if (getLayerZeroLaneByRemoteChainId(resolvedRemoteChainId)) {
+        activeReceiverByRemoteChainId.set(
+          resolvedRemoteChainId,
+          decodeLayerZeroRemoteAddress(remoteAddress, i),
+        );
+      }
+      continue;
+    }
+
+    if (selector !== LAYER_ZERO_EXECUTE_SELECTOR) continue;
 
     const decoded = (() => {
       try {
@@ -194,8 +236,6 @@ export function extractLayerZeroL1L2JobsFromProposal(
         throw new Error(`Malformed LayerZero execute calldata in proposal calldata index ${i}`);
       }
     })();
-
-    if (decoded.functionName !== 'execute') continue;
 
     const [remoteChainId, payload] = decoded.args;
     const resolvedRemoteChainId = Number(remoteChainId);
@@ -221,7 +261,7 @@ export function extractLayerZeroL1L2JobsFromProposal(
     jobs.push({
       bridgeType: 'LayerZeroL1L2',
       destinationChainId: lane.destinationChainId,
-      l2FromAddress: lane.l2FromAddress,
+      l2FromAddress: activeReceiverByRemoteChainId.get(resolvedRemoteChainId) ?? lane.l2FromAddress,
       layerZeroTrustedRemote: {
         sourceRemoteChainId: LAYER_ZERO_ETHEREUM_REMOTE_CHAIN_ID,
         expectedRemoteAddress: lane.senderTarget,


### PR DESCRIPTION
## Summary
- Tracks in-proposal `setTrustedRemoteAddress` calls on known LayerZero sender targets.
- Uses the active receiver for later `execute` jobs, so Proposal 98 can simulate both MegaETH receivers without hardcoding the second receiver in production code.
- Keeps existing receiver trusted-remote validation before replaying destination calls.

## Test Plan
- Automated: `bun test tests/layerzero-parser.test.ts tests/layerzero-execution.test.ts checks/tests/cross-chain-execution-engine.test.ts`
- Automated: `bun test tests checks`
- Automated: `bun run typecheck`, `bunx biome check .`, `bun run contract:check`, `cd frontend && bun run check`
- Automated: `cd frontend && /Users/dev/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/next/dist/bin/next build`
- Manual: ran Proposal 98 locally with PR #269 sim/Tenderly chunking; report emitted LayerZero jobs for MegaETH `0x8819...`, Avalanche `0xeb0...`, and MegaETH `0x51F...`.