### PR TITLE
fix: clarify cross-chain receivers

### DIFF
--- a/frontend/src/components/CallGroupedView.test.tsx
+++ b/frontend/src/components/CallGroupedView.test.tsx
@@ -125,9 +125,10 @@ describe('CallGroupedView cross-chain summary headers', () => {
     expect(html).toContain('bridgeSecond');
     expect(html).toContain('cleanup');
     expect(html).toContain('3 cross-chain destination calls');
-    expect(html).toContain('2 destination calls');
+    expect(html).toContain('3 destination calls');
     expect(html).toContain('via Arbitrum');
     expect(html).not.toContain('via ArbitrumL1L2');
+    expect(html).toContain('From');
     expect(html).toContain('Arbitrum target 1');
     expect(html).toContain('Arbitrum target 2');
     expect(html).toContain('0x2222222222222222222222222222222222222222');
@@ -137,6 +138,50 @@ describe('CallGroupedView cross-chain summary headers', () => {
     );
     expect(html).not.toContain('1 step');
     expect(html).not.toContain('2 steps');
+  });
+
+  it('labels LayerZero job sources as receivers', () => {
+    const html = renderToStaticMarkup(
+      createElement(CallGroupedView, {
+        proposal,
+        report: makeReport([
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9',
+          }),
+        ]),
+      }),
+    );
+
+    expect(html).toContain('via LayerZero');
+    expect(html).toContain('Receiver');
+    expect(html).toContain('0x51F9...efd9');
+  });
+
+  it('keeps different LayerZero receivers in separate cards', () => {
+    const html = renderToStaticMarkup(
+      createElement(CallGroupedView, {
+        proposal,
+        report: makeReport([
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c',
+          }),
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9',
+            sourceOrder: 1,
+          }),
+        ]),
+      }),
+    );
+
+    expect(html).toContain('0x8819...322c');
+    expect(html).toContain('0x51F9...efd9');
+    expect(html.match(/1 destination call/g) ?? []).toHaveLength(2);
   });
 
   it('shows forwarded inner calls in the detailed cross-chain call list', () => {

--- a/frontend/src/components/CallGroupedView.tsx
+++ b/frontend/src/components/CallGroupedView.tsx
@@ -25,9 +25,11 @@ import { ChainLogo } from './structured-report/ChainLogo';
 import {
   formatBridgeType,
   formatCrossChainCall,
+  getCrossChainJobSourceLabel,
   getCrossChainStepTarget,
   getCrossChainStepTargetLabel,
   getCrossChainTransportLabel,
+  groupCrossChainJobsByDisplayedSource,
 } from './structured-report/cross-chain';
 
 type RiskTag = 'Upgrade' | 'Admin/Role' | 'Token Approval' | 'Token Transfer' | 'ETH Value';
@@ -1012,41 +1014,61 @@ function CrossChainCallsSection({
               </div>
             </div>
 
-            {chainJobs.map((job) => {
-              const stepCount = job.steps.length;
+            {groupCrossChainJobsByDisplayedSource(chainJobs).map((jobGroup) => {
+              const firstJob = jobGroup[0];
+              if (!firstJob) return null;
+
+              const sourceOrders = jobGroup.map((job) => job.sourceOrder).join('-');
+              const groupKey = `${firstJob.bridgeType}-${firstJob.l2FromAddress}-${firstJob.status}-${sourceOrders}`;
+              const groupSteps = jobGroup.flatMap((job) => job.steps.map((msg) => ({ job, msg })));
+              const stepCount = groupSteps.length;
+              const sourceLabel = getCrossChainJobSourceLabel(firstJob);
 
               return (
                 <div
-                  key={`${chainId}-${job.sourceOrder}`}
+                  key={`${chainId}-${groupKey}`}
                   className="border border-muted rounded-lg p-3 bg-card space-y-2"
                 >
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
                     <div className="flex items-center gap-2 min-w-0">
                       <span className="text-sm font-medium">
                         {stepCount} destination call{stepCount === 1 ? '' : 's'}
                       </span>
-                      {job.status === 'skipped' && (
+                      {firstJob.status === 'skipped' && (
                         <Badge variant="outline" className="text-[10px] px-1.5 py-0">
                           Skipped
                         </Badge>
                       )}
-                      {job.status === 'failure' && (
+                      {firstJob.status === 'failure' && (
                         <Badge variant="destructive" className="text-[10px] px-1.5 py-0">
                           Failed
                         </Badge>
                       )}
                     </div>
+                    {firstJob.l2FromAddress ? (
+                      <div className="inline-flex items-center gap-1 text-[11px] text-muted-foreground shrink-0">
+                        <span>{sourceLabel}</span>
+                        <ExplorerAddressLink
+                          address={firstJob.l2FromAddress}
+                          baseUrl={explorerBaseUrl}
+                          className="font-mono hover:underline"
+                        >
+                          {firstJob.l2FromAddress.slice(0, 6)}...
+                          {firstJob.l2FromAddress.slice(-4)}
+                        </ExplorerAddressLink>
+                      </div>
+                    ) : null}
                   </div>
 
-                  {job.error && (
+                  {firstJob.error && (
                     <div className="p-2 bg-red-100 border border-red-200 rounded text-red-800 text-[11px]">
-                      {job.error}
+                      {firstJob.error}
                     </div>
                   )}
 
                   <div className="space-y-2">
                     {stepCount ? (
-                      job.steps.map((msg, index) => {
+                      groupSteps.map(({ job, msg }, index) => {
                         const visibleSignature = formatCrossChainCall(msg);
                         const transportLabel = getCrossChainTransportLabel(msg);
                         const stepTarget = getCrossChainStepTarget(msg);
@@ -1057,7 +1079,7 @@ function CrossChainCallsSection({
 
                         return (
                           <details
-                            key={`${chainId}-${job.sourceOrder}-${index}`}
+                            key={`${chainId}-${job.sourceOrder}-${msg.stepIndex}-${index}`}
                             className={`group border rounded ${isFailed ? 'border-red-200 bg-red-50/50' : 'border-muted/60'}`}
                           >
                             <summary className="cursor-pointer select-none px-2.5 py-1.5 flex items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
@@ -1118,11 +1140,13 @@ function CrossChainCallsSection({
                                 </div>
                               )}
 
-                              {job.l2FromAddress && (
+                              {firstJob.l2FromAddress && (
                                 <div className="flex items-center gap-3">
-                                  <span className="text-muted-foreground w-14 shrink-0">From</span>
+                                  <span className="text-muted-foreground w-14 shrink-0">
+                                    {sourceLabel}
+                                  </span>
                                   <AddressValue
-                                    address={job.l2FromAddress}
+                                    address={firstJob.l2FromAddress}
                                     baseUrl={explorerBaseUrl}
                                     labels={labels}
                                     chainId={chainId}
@@ -1156,7 +1180,7 @@ function CrossChainCallsSection({
 
                                     return (
                                       <div
-                                        key={`${chainId}-${job.sourceOrder}-${index}-arg-${argIndex}`}
+                                        key={`${chainId}-${job.sourceOrder}-${msg.stepIndex}-${index}-arg-${argIndex}`}
                                         className="flex items-center gap-3"
                                       >
                                         <span className="text-muted-foreground w-14 shrink-0 truncate">

--- a/frontend/src/components/structured-report/CrossChainPreview.test.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.test.tsx
@@ -50,13 +50,56 @@ describe('CrossChainPreview', () => {
     expect(html).toContain('Arbitrum target 2');
     expect(html).toContain('bridgeAction1()');
     expect(html).toContain('bridgeAction2()');
+    expect(html).toContain('From');
     expect(html).toContain('0x2222222222222222222222222222222222222222');
     expect(html).toContain('0x3333333333333333333333333333333333333333');
-    expect(html).toContain('2 destination calls');
+    expect(html).toContain('3 destination calls');
     expect(html).not.toContain('Action 1');
     expect(html).not.toContain('Action 2');
     expect(html).not.toContain('Execution 2');
     expect(html).not.toContain('1 step');
     expect(html).not.toContain('2 steps');
+  });
+
+  it('labels LayerZero job sources as receivers', () => {
+    const html = renderToStaticMarkup(
+      createElement(CrossChainPreview, {
+        jobs: [
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9',
+          }),
+        ],
+      }),
+    );
+
+    expect(html).toContain('LayerZero');
+    expect(html).toContain('Receiver');
+    expect(html).toContain('0x51F9...efd9');
+  });
+
+  it('keeps different LayerZero receivers in separate cards', () => {
+    const html = renderToStaticMarkup(
+      createElement(CrossChainPreview, {
+        jobs: [
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c',
+          }),
+          makeJob({
+            bridgeType: 'LayerZeroL1L2',
+            chainName: 'MegaETH',
+            l2FromAddress: '0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9',
+            sourceOrder: 1,
+          }),
+        ],
+      }),
+    );
+
+    expect(html).toContain('0x8819...322c');
+    expect(html).toContain('0x51F9...efd9');
+    expect(html.match(/1 destination call/g) ?? []).toHaveLength(2);
   });
 });

--- a/frontend/src/components/structured-report/CrossChainPreview.tsx
+++ b/frontend/src/components/structured-report/CrossChainPreview.tsx
@@ -9,9 +9,11 @@ import { ChainLogo } from './ChainLogo';
 import {
   formatBridgeType,
   formatCrossChainCall,
+  getCrossChainJobSourceLabel,
   getCrossChainStepTarget,
   getCrossChainStepTargetLabel,
   getCrossChainTransportLabel,
+  groupCrossChainJobsByDisplayedSource,
 } from './cross-chain';
 import { buildAddressLinkForExplorer } from './explorer';
 
@@ -80,22 +82,50 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
             </div>
 
             <div className="space-y-2">
-              {chainJobs.map((job) => {
-                const jobKey = `${job.chainId}-${job.bridgeType}-${job.sourceOrder}-${job.l2FromAddress}-${job.status}`;
-                const stepCount = job.steps.length;
+              {groupCrossChainJobsByDisplayedSource(chainJobs).map((jobGroup) => {
+                const firstJob = jobGroup[0];
+                if (!firstJob) return null;
+
+                const sourceOrders = jobGroup.map((job) => job.sourceOrder).join('-');
+                const jobKey = `${firstJob.chainId}-${firstJob.bridgeType}-${sourceOrders}-${firstJob.l2FromAddress}-${firstJob.status}`;
+                const groupSteps = jobGroup.flatMap((job) =>
+                  job.steps.map((step) => ({ job, step })),
+                );
+                const stepCount = groupSteps.length;
+                const sourceLabel = getCrossChainJobSourceLabel(firstJob);
 
                 return (
                   <div key={jobKey} className="border border-border/40 rounded bg-muted/20 p-2.5">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="text-xs font-medium">
-                        {stepCount} destination call{stepCount === 1 ? '' : 's'}
+                      <div className="min-w-0">
+                        <div className="text-xs font-medium">
+                          {stepCount} destination call{stepCount === 1 ? '' : 's'}
+                        </div>
+                        {firstJob.l2FromAddress ? (
+                          <div className="mt-0.5 text-[10px] text-muted-foreground">
+                            {sourceLabel}{' '}
+                            <a
+                              href={buildAddressLinkForExplorer(
+                                firstJob.l2FromAddress,
+                                explorerBaseUrl,
+                              )}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="font-mono hover:text-foreground"
+                              title={firstJob.l2FromAddress}
+                            >
+                              {firstJob.l2FromAddress.slice(0, 6)}...
+                              {firstJob.l2FromAddress.slice(-4)}
+                            </a>
+                          </div>
+                        ) : null}
                       </div>
-                      <CrossChainStatusBadge status={job.status} />
+                      <CrossChainStatusBadge status={firstJob.status} />
                     </div>
 
                     {stepCount ? (
                       <div className="mt-2 space-y-2">
-                        {job.steps.map((step, index) => {
+                        {groupSteps.map(({ job, step }, index) => {
                           const target = getCrossChainStepTarget(step);
                           const targetLabel = getCrossChainStepTargetLabel(step);
                           const call = formatCrossChainCall(step);
@@ -103,7 +133,7 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
 
                           return (
                             <div
-                              key={`${jobKey}-${step.stepIndex}-${index}`}
+                              key={`${jobKey}-${job.sourceOrder}-${step.stepIndex}-${index}`}
                               className="rounded border border-border/30 bg-background/70 p-2"
                             >
                               <div className="flex items-center justify-between gap-2">
@@ -158,8 +188,8 @@ export function CrossChainPreview({ jobs }: { jobs: CrossChainJobPreview[] }) {
                       </code>
                     )}
 
-                    {job.error ? (
-                      <div className="text-[10px] text-red-600 mt-1">{job.error}</div>
+                    {firstJob.error ? (
+                      <div className="text-[10px] text-red-600 mt-1">{firstJob.error}</div>
                     ) : null}
                   </div>
                 );

--- a/frontend/src/components/structured-report/cross-chain.ts
+++ b/frontend/src/components/structured-report/cross-chain.ts
@@ -17,6 +17,29 @@ export function formatBridgeType(bridgeType: string | undefined): string | undef
   return BRIDGE_TYPE_LABELS[bridgeType] ?? bridgeType;
 }
 
+export function getCrossChainJobSourceLabel(job: CrossChainJobPreview): string {
+  return job.bridgeType === 'LayerZeroL1L2' ? 'Receiver' : 'From';
+}
+
+export function groupCrossChainJobsByDisplayedSource(
+  jobs: CrossChainJobPreview[],
+): CrossChainJobPreview[][] {
+  const groups = new Map<string, CrossChainJobPreview[]>();
+
+  for (const job of jobs) {
+    const key = [job.bridgeType, job.l2FromAddress.toLowerCase(), job.status, job.error ?? ''].join(
+      ':',
+    );
+    const group = groups.get(key) ?? [];
+    group.push(job);
+    groups.set(key, group);
+  }
+
+  return Array.from(groups.values()).map((group) =>
+    [...group].sort((a, b) => a.sourceOrder - b.sourceOrder),
+  );
+}
+
 export function formatCrossChainCall(step: CrossChainJobStepPreview): string {
   if (step.forwardedCall?.signature) return step.forwardedCall.signature;
   if (step.forwardedCall?.selector) return step.forwardedCall.selector;


### PR DESCRIPTION
## Summary
- Show the cross-chain sender/receiver address on each job card in Overview and Calls.
- Group same chain + bridge + sender/receiver jobs into one card, so OP Stack paths read as `2 destination calls` instead of duplicate `1 destination call` cards.
- Label LayerZero job sources as Receiver and keep different MegaETH receivers separate.

## Test Plan
- Automated: `bun test frontend/src/components/CallGroupedView.test.tsx frontend/src/components/structured-report/CrossChainPreview.test.tsx frontend/src/components/structured-report/cross-chain.test.ts` verifies grouped same-source cards and separate LayerZero receivers in both cross-chain views.
- Automated: `bun run typecheck` verifies the repo TypeScript compile.
- Automated: `cd frontend && bun run check` verifies frontend typecheck and Biome.
- Manual: inspected Proposal 98 locally and confirmed MegaETH keeps separate receiver cards while Soneium/X Layer collapse to `2 destination calls`.