### PR TITLE
feat: add Proposal 98 simulation

### DIFF
--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -33,28 +33,22 @@ const ETHEREUM = {
 const MEGA = {
   OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress('0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c'),
   OMNICHAIN_GOVERNANCE_EXECUTOR_2: getAddress('0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9'),
-  LZ_ENDPOINT: getAddress('0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7'),
   WORMHOLE_RECEIVER: getAddress('0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB'),
   V2_FACTORY: getAddress('0xbf56488c857A881ae7e3BED27Cf99c10A7Ab7e50'),
   V3_FACTORY: getAddress('0x3a5F0CD7d62452b7f899B2A5758BFa57be0dE478'),
   POOL_MANAGER: getAddress('0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E'),
   V3_PROXY_ADMIN: getAddress('0xdaFBcEB5cA32Dc1DD27A413dA361F32636694BC4'),
   V4_PROXY_ADMIN: getAddress('0x07e7c1cEd961e2C11196751A1aC76E64b0e8b007'),
-  V3_POSITION_DESCRIPTOR: getAddress('0x8D9F62d363486ebadD3F3d735301a99a487a8fD8'),
-  V4_POSITION_DESCRIPTOR: getAddress('0xA9fDbB9D3dce2e1cFB91c4AF1B8Cf4ed62c0041A'),
 };
 
 const AVAX = {
   OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress('0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc'),
-  LZ_ENDPOINT: getAddress('0x3c2269811836af69497E5F486A85D7316753cf62'),
   WORMHOLE_RECEIVER: getAddress('0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6'),
   V2_FACTORY: getAddress('0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C'),
   V3_FACTORY: getAddress('0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD'),
   POOL_MANAGER: getAddress('0x06380C0e0912312B5150364B9DC4542BA0DbBc85'),
   V3_PROXY_ADMIN: getAddress('0x9AdA7D7879214073F40183F3410F2b3f088c6381'),
   V4_PROXY_ADMIN: getAddress('0x9b0481d2A2912051f56dC0B806cafe6bdE461c3D'),
-  V3_POSITION_DESCRIPTOR: getAddress('0xE1f93a7cB6fFa2dB4F9d5A2FD43158A428993C09'),
-  V4_POSITION_DESCRIPTOR: getAddress('0x2b1AED9445B05AC1A3B203eCCC1e25dD9351F0A9'),
 };
 
 const SONEIUM = {
@@ -75,6 +69,12 @@ const LZ_AVAX_CHAIN_ID = 106;
 const LZ_MEGA_CHAIN_ID = 398;
 
 const FLAT_LAYER_ZERO_FEE = BigInt(0.01 * 1e18);
+const LAYER_ZERO_ADAPTER_PARAMS_VERSION = 1;
+const LAYER_ZERO_MSG_GAS = 3_000_000n;
+const LAYER_ZERO_ADAPTER_PARAMS = encodePacked(
+  ["uint16", "uint256"],
+  [LAYER_ZERO_ADAPTER_PARAMS_VERSION, LAYER_ZERO_MSG_GAS]
+);
 
 // -------------------------------------------------------------------------------------------------
 // 00: (Ethereum) Set Layer Zero Trusted Remote For Mega
@@ -156,7 +156,7 @@ const megaTransferOwnershipFromLzToWormhole = {
           megaLzTransferOwnershipCalls.map((lzCall) => lzCall.calldata),
         ],
       ),
-      '0x',
+      LAYER_ZERO_ADAPTER_PARAMS,
     ],
   }),
 };
@@ -237,7 +237,7 @@ const avaxTransferOwnershipFromLztoWormhole = {
           avaxLzTransferOwnershipCalls.map((lzCall) => lzCall.calldata),
         ],
       ),
-      '0x',
+      LAYER_ZERO_ADAPTER_PARAMS,
     ],
   }),
 };
@@ -339,9 +339,9 @@ const xLayerPoolManagerTransferOwnership = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 07: (Ethereum) Set Layer Zero Trusted Remote For Mega (OPTIONAL)
+// 07: (Ethereum) Set Layer Zero Trusted Remote For Mega
 //
-const ethSetTrustedRemoteToMega0x55 = {
+const ethSetTrustedRemoteToMega0x51 = {
   target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
   value: 0n,
   signature: '',
@@ -353,7 +353,7 @@ const ethSetTrustedRemoteToMega0x55 = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 08: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
+// 08: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor
 //
 const megaTransferProxyAdminOwnership = {
   target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
@@ -381,7 +381,7 @@ const megaTransferProxyAdminOwnership = {
           ],
         ],
       ),
-      '0x',
+      LAYER_ZERO_ADAPTER_PARAMS,
     ],
   }),
 };
@@ -394,7 +394,7 @@ const actions = [
   soneiumPoolManagerTransferOwnership,
   xLayerV2SetFeeToSetter,
   xLayerPoolManagerTransferOwnership,
-  ethSetTrustedRemoteToMega0x55,
+  ethSetTrustedRemoteToMega0x51,
   megaTransferProxyAdminOwnership,
 ];
 

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -1,4 +1,4 @@
-import { encodeAbiParameters, encodeFunctionData, encodePacked, getAddress, parseAbi, parseAbiParameter, parseAbiParameters, parseEther, parseGwei, toBytes } from 'viem';
+import { encodeAbiParameters, encodeFunctionData, encodePacked, getAddress, parseAbi, parseAbiParameters } from 'viem';
 
 import type { SimulationConfigNew } from "../types";
 
@@ -75,6 +75,8 @@ const X_LAYER = {
 const LZ_AVAX_CHAIN_ID = 106;
 const LZ_MEGA_CHAIN_ID = 398;
 
+const FLAT_LAYER_ZERO_FEE = BigInt(0.01 * 1e18);
+
 // -------------------------------------------------------------------------------------------------
 // 00: (Ethereum) Set Layer Zero Trusted Remote For Mega
 //
@@ -140,7 +142,7 @@ const megaLzTransferOwnershipCalls = [
 
 const megaTransferOwnershipFromLzToWormhole = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: 0n,
+    value: FLAT_LAYER_ZERO_FEE,
     signature: "",
     calldata: encodeFunctionData({
         abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
@@ -223,7 +225,7 @@ const avaxLzTransferOwnershipCalls = [
 
 const avaxTransferOwnershipFromLztoWormhole = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: 0n,
+    value: FLAT_LAYER_ZERO_FEE,
     signature: "",
     calldata: encodeFunctionData({
         abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
@@ -360,9 +362,9 @@ const ethSetTrustedRemoteToMega0x55 = {
 // -------------------------------------------------------------------------------------------------
 // 08: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
 //
-const megaChangeProxyAdmin = {
+const megaTransferProxyAdminOwnership = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: 0n,
+    value: FLAT_LAYER_ZERO_FEE,
     signature: "",
     calldata: encodeFunctionData({
         abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
@@ -400,7 +402,7 @@ const actions = [
     xLayerV2SetFeeToSetter,
     xLayerPoolManagerTransferOwnership,
     ethSetTrustedRemoteToMega0x55,
-    megaChangeProxyAdmin,
+    megaTransferProxyAdminOwnership,
 ];
 
 export const config: SimulationConfigNew = {
@@ -504,13 +506,13 @@ Execute nine actions:
 
 8. (Ethereum) Set Layer Zero "trusted remote" to the second OmnichainGovernanceExecutor on MegaETH
 
-9. (MegaETH) Consolidate ProxyAdmin ownership from the second OmnichainGovernanceExecutor to UniswapWormholeReceiver
+9. (MegaETH) Transfer ProxyAdmin ownership from the second OmnichainGovernanceExecutor to UniswapWormholeReceiver
 
 Notable Implementation Details:
 
 Regarding MegaETH "trusted remote" configurations: The OmnichainProposalSender on Ethereum must be configured to send messages to the OmnichainGovernanceExecutor on MegaETH, but not the OmnichainGovernanceExecutor on Avalanche. This is due to our OmnichainProposalSender's configuration on initial deployment. The "trusted remote" is Layer Zero's means of defining which sender contracts may interact with which receiver contracts.
 
-Regarding ProxyAdmin: There exists two ProxyAdmin contracts per chain, one for the NonfungiblePositionDescriptor (V3 NFT renderer) and one for the PositionDescriptor (V4 NFT renderer). Since ProxyAdmin contracts are designed to administer arbitrarily many proxy contracts, it seems reasonable to consolidate the proxy admin authority of both position descriptors while performing an ownership transition.
+Regarding ProxyAdmin: There exists two ProxyAdmin contracts per chain, one for the NonfungiblePositionDescriptor (V3 NFT renderer) and one for the PositionDescriptor (V4 NFT renderer). The ProxyAdmin of the V3 descriptor is owned a different OmnichainGovernanceExecutor than the OmnichainGovernanceExecutor which owns the rest of the protocol (including the V4 descriptor). We are transferring ownership of all of them to the same WormholeReceiver, which necessitates two separate "setTrustedRemote" actions (one for each governance executor) and two separate ownership transfer actions.
 
 Regarding CrossChainAccount: The low level OP-stack chain bridge uses OptimismPortal2. In short, OptimismPortal2's internal details means the protocol on Soneium and X Layer are owned by an "aliased" form of the Timelock address on Ethereum; this alias is derived from adding a standard offset to the Ethereum address. This is an unintuitive system and increases user-error in ownership transitions, so we are migrating to the higher level of abstraction defined by the CrosChainAccount system. This ensures the protocol on Soneium and X Layer are owned by a concrete contract with limits and authority checks from the messages bridged from Ethereum. We already use this system on other OP-stack chains, so this is to update more chains to use it as well. 
 ---

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -8,8 +8,7 @@ const OMNICHAIN_PROPOSAL_SENDER_ABI = parseAbi([
 ]);
 
 const PROXY_ADMIN_ABI = parseAbi([
-    "function transferOwnership(address)",
-    "function changeProxyAdmin(address proxy, address newAdmin)"
+    "function transferOwnership(address)"
 ]);
 
 const V2_FACTORY_ABI = parseAbi([
@@ -202,10 +201,9 @@ const avaxLzTransferOwnershipCalls = [
         signature: "",
         calldata: encodeFunctionData({
             abi: PROXY_ADMIN_ABI,
-            functionName: "changeProxyAdmin",
+            functionName: "transferOwnership",
             args: [
-                AVAX.V3_POSITION_DESCRIPTOR,
-                AVAX.V4_PROXY_ADMIN,
+                AVAX.WORMHOLE_RECEIVER
             ]
         })
     },
@@ -380,10 +378,9 @@ const megaChangeProxyAdmin = {
                     [
                         encodeFunctionData({
                             abi: PROXY_ADMIN_ABI,
-                            functionName: "changeProxyAdmin",
+                            functionName: "transferOwnership",
                             args: [
-                                MEGA.V3_POSITION_DESCRIPTOR,
-                                MEGA.V4_PROXY_ADMIN
+                                AVAX.WORMHOLE_RECEIVER
                             ]
                         })
                     ],

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -72,8 +72,8 @@ const FLAT_LAYER_ZERO_FEE = BigInt(0.01 * 1e18);
 const LAYER_ZERO_ADAPTER_PARAMS_VERSION = 1;
 const LAYER_ZERO_MSG_GAS = 3_000_000n;
 const LAYER_ZERO_ADAPTER_PARAMS = encodePacked(
-  ["uint16", "uint256"],
-  [LAYER_ZERO_ADAPTER_PARAMS_VERSION, LAYER_ZERO_MSG_GAS]
+  ['uint16', 'uint256'],
+  [LAYER_ZERO_ADAPTER_PARAMS_VERSION, LAYER_ZERO_MSG_GAS],
 );
 
 // -------------------------------------------------------------------------------------------------

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -376,7 +376,7 @@ const megaTransferProxyAdminOwnership = {
             encodeFunctionData({
               abi: PROXY_ADMIN_ABI,
               functionName: 'transferOwnership',
-              args: [AVAX.WORMHOLE_RECEIVER],
+              args: [MEGA.WORMHOLE_RECEIVER],
             }),
           ],
         ],

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -77,7 +77,7 @@ const LZ_AVAX_CHAIN_ID = 106;
 const LZ_MEGA_CHAIN_ID = 398;
 
 // -------------------------------------------------------------------------------------------------
-// NN: (Ethereum) Set Layer Zero Trusted Remote For Mega
+// 00: (Ethereum) Set Layer Zero Trusted Remote For Mega
 //
 const ethSetTrustedRemoteToMega0x88 = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
@@ -94,7 +94,7 @@ const ethSetTrustedRemoteToMega0x88 = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: (Mega) Transfer Ownership on MegaETH from Layer Zero to Wormhole
+// 01: (Mega) Transfer Ownership on MegaETH from Layer Zero to Wormhole
 //
 const megaLzTransferOwnershipCalls = [
     {
@@ -163,7 +163,7 @@ const megaTransferOwnershipFromLzToWormhole = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: Transfer Ownership on Avax from Layer Zero to Wormhole
+// 02: Transfer Ownership on Avax from Layer Zero to Wormhole
 //
 const avaxLzTransferOwnershipCalls = [
         {
@@ -247,7 +247,7 @@ const avaxTransferOwnershipFromLztoWormhole = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
+// 03: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumV2SetFeeToSetter = {
     target: SONEIUM.OPTIMISM_PORTAL2,
@@ -271,7 +271,7 @@ const soneiumV2SetFeeToSetter = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
+// 04: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumPoolManagerTransferOwnership = {
     target: SONEIUM.OPTIMISM_PORTAL2,
@@ -295,7 +295,7 @@ const soneiumPoolManagerTransferOwnership = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 06: Transfer V2 Fee Setter on XLayer from OptimismPortal2 to CrossChainAccount
+// 05: Transfer V2 Fee Setter on XLayer from OptimismPortal2 to CrossChainAccount
 //
 const xLayerV2SetFeeToSetter = {
     target: X_LAYER.OPTIMISM_PORTAL2,
@@ -319,7 +319,7 @@ const xLayerV2SetFeeToSetter = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
+// 06: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
 //
 const xLayerPoolManagerTransferOwnership = {
     target: X_LAYER.OPTIMISM_PORTAL2,
@@ -343,7 +343,7 @@ const xLayerPoolManagerTransferOwnership = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: (Ethereum) Set Layer Zero Trusted Remote For Mega (OPTIONAL)
+// 07: (Ethereum) Set Layer Zero Trusted Remote For Mega (OPTIONAL)
 //
 const ethSetTrustedRemoteToMega0x55 = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
@@ -360,7 +360,7 @@ const ethSetTrustedRemoteToMega0x55 = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// NN: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
+// 08: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
 //
 const megaChangeProxyAdmin = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -416,27 +416,19 @@ export const config: SimulationConfigNew = {
     signatures: actions.map(action => action.signature),
     calldatas: actions.map(action => action.calldata),
     description: `
-# [RFC] Update Crosschain Governance Parameters for Avalanche, MegaETH, Soneium, and X Layer
+    # [RFC] Update Crosschain Governance Parameters for Avalanche, MegaETH, Soneium, and X Layer
 
 ## Summary
 
 Secure crosschain messaging is an integral part of Uniswap's governance model. Governance votes like protocol fee adjustments are executed by UNI holders on Ethereum Mainnet and must subsequently be relayed to destination chains.
 
-
-
 This proposal updates Uniswap's crosschain governance system to accommodate the latest best practices. Specifically, we propose to:
-
-
 
 * Transition ownership of the Uniswap v2 and v4 contracts on Soneium and X Layer to CrossChainAccount contracts, which we consider to be the current best practice for executing messages from Ethereum Mainnet on the OP Stack
 
 * Migrate the entire messaging system for the Avalanche and MegaETH deployments from LayerZero v1 (part of which is [being deprecated](https://layerzero.network/blog/ongoing-security-updates)) to Wormhole 
 
-
-
 Note that because Uniswap v3 on both Soneium and X Layer is owned by the \`v3OpenFeeAdapter\`, which is owned by the CrossChainAccount, we do not need to change the parameter on v3 on these chains.
-
-
 
 ---
 
@@ -444,13 +436,14 @@ Note that because Uniswap v3 on both Soneium and X Layer is owned by the \`v3Ope
 
 ### Current Configuration - Avalanche and MegaETH
 
-Both chains currently use LayerZero v1 for governance messaging:
+Both chains currently use LayerZero v1 for governance messaging. The OmnichainProposalSender contract exists on Ethereum and sends messages to OmnichainGovernanceExecutor on remote chains. Additionally, there exists a second OmnichainGovernanceExecutor on MegaETH which owns the ProxyAdmin contract administering the PositionDescriptor periphery contract responsible for rendering LP positions as NFT's.
 
 | Contract | Chain | Address |
 | :---- | :---- | :---- |
 | OmnichainProposalSender | Ethereum | [0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc](https://etherscan.io/address/0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc) |
 | OmnichainGovernanceExecutor | Avalanche | [0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc](https://snowtrace.io/address/0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc) |
-| OmnichainGovernanceExecutor | MegaETH | [0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c](https://explorer.megaeth.com/address/0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c) |
+| OmnichainGovernanceExecutor | MegaETH | [0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c](https://mega.etherscan.io/address/0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c) |
+| OmnichainGovernanceExecutor | MegaETH | [0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9](https://mega.etherscan.io/address/0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9) |
 
 ### Proposed Configuration - Avalanche and MegaETH
 
@@ -458,13 +451,13 @@ The LayerZero contracts are replaced with the Wormhole bridge infrastructure fro
 
 **UniswapWormholeSender (Ethereum):** The existing sender contract already deployed on mainnet will be reused — no new deployment required. 
 
-**UniswapWormholeReceiver (Avalanche and MegaETH):** Uniswap Labs has deployed new UniswapWormholeReceiver contracts on both chains. This proposal will authorize them as the trusted governance executors for each chain.
+**UniswapWormholeReceiver (Avalanche and MegaETH):** Uniswap Labs has deployed new UniswapWormholeReceiver contracts on both chains. This proposal will authorize them as the trusted governance executors for each chain. Additionally, the ProxyAdmin owned by the second OmnichainGovernanceExecutor will be unified with under the authority of the UniswapWormholeReceiver on MegaETH.
 
 | Contract | Chain | Address |
 | :---- | :---- | :---- |
 | UniswapWormholeSender | Ethereum | [0xf5F4496219F31CDCBa6130B5402873624585615a](https://etherscan.io/address/0xf5F4496219F31CDCBa6130B5402873624585615a) |
 | UniswapWormholeReceiver | Avalanche | [0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6](https://snowtrace.io/address/0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6) |
-| UniswapWormholeReceiver | MegaETH | [0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB](https://explorer.megaeth.com/address/0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB) |
+| UniswapWormholeReceiver | MegaETH | [0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB](https://mega.etherscan.io/address/0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB) |
 
 For a detailed discussion of how Wormhole works, please see [this report](https://uniswap.notion.site/Assessment-dac583c6db1240c7b9d294afd7f18035) by the Uniswap Foundation's Bridge Assessment Committee.
 
@@ -496,32 +489,40 @@ This proposal will change those parameters to a CrossChainAccount contract deplo
 
 **In this proposal** (executed if the vote passes):
 
-Execute seven actions:
+Execute nine actions:
 
-1. Finalize LayerZero configuration on MegaETH
+1. (Ethereum) Set Layer Zero "trusted remote" to the OmnichainGovernanceExecutor on MegaETH
 
-2. Transfer ownership of the protocol on MegaETH from LayerZero to Wormhole 
+2. (MegaETH) Transfer ownership of the protocol from OmnichainGovernanceExecutor to UniswapWormholeReceiver
 
-3. Transfer ownership of the protocol on Avalanche from LayerZero to Wormhole
+3. (Avalanche) Transfer ownership of the protocol from OmnichainGovernanceExecutor to UniswapWormholeReceiver
 
-4. Change v2's \`feeToSetter\` on X Layer from the alias address to the \`CrosschainAccount\`
+4. (Soneium) Transfer V2 ownership from the aliased Timelock to CrossChainAccount
 
-5. Change v4's \`owner\` on X Layer from the alias address to the \`CrosschainAccount\`
+5. (Soneium) Transfer V4 ownership from the aliased Timelock to CrossChainAccount
 
-6. Change v2's \`feeToSetter\` on Soneium from the alias address to the \`CrosschainAccount\`
+6. (XLayer) Transfer V2 ownership from aliased Timelock to CrossChainAccount
 
-7. Change v4's \`owner\` on Soneium from the alias address to the \`CrosschainAccount\`
+7. (XLayer) Transfer V4 ownership from the aliased Timelock to CrossChainAccount
 
+8. (Ethereum) Set Layer Zero "trusted remote" to the second OmnichainGovernanceExecutor on MegaETH
 
+9. (MegaETH) Consolidate ProxyAdmin ownership from the second OmnichainGovernanceExecutor to UniswapWormholeReceiver
 
+Notable Implementation Details:
+
+Regarding MegaETH "trusted remote" configurations: The OmnichainProposalSender on Ethereum must be configured to send messages to the OmnichainGovernanceExecutor on MegaETH, but not the OmnichainGovernanceExecutor on Avalanche. This is due to our OmnichainProposalSender's configuration on initial deployment. The "trusted remote" is Layer Zero's means of defining which sender contracts may interact with which receiver contracts.
+
+Regarding ProxyAdmin: There exists two ProxyAdmin contracts per chain, one for the NonfungiblePositionDescriptor (V3 NFT renderer) and one for the PositionDescriptor (V4 NFT renderer). Since ProxyAdmin contracts are designed to administer arbitrarily many proxy contracts, it seems reasonable to consolidate the proxy admin authority of both position descriptors while performing an ownership transition.
+
+Regarding CrossChainAccount: The low level OP-stack chain bridge uses OptimismPortal2. In short, OptimismPortal2's internal details means the protocol on Soneium and X Layer are owned by an "aliased" form of the Timelock address on Ethereum; this alias is derived from adding a standard offset to the Ethereum address. This is an unintuitive system and increases user-error in ownership transitions, so we are migrating to the higher level of abstraction defined by the CrosChainAccount system. This ensures the protocol on Soneium and X Layer are owned by a concrete contract with limits and authority checks from the messages bridged from Ethereum. We already use this system on other OP-stack chains, so this is to update more chains to use it as well. 
 ---
 
 ## Next Steps / Timeline
 
-* **RFC:** Jun 19, 2026
+* **RFC:** Jun 26, 2026
 
 * **Snapshot:** \~1 week after RFC
-
 * **Onchain vote:** Following Snapshot, per standard governance cadence
 
 ---

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -7,6 +7,11 @@ const OMNICHAIN_PROPOSAL_SENDER_ABI = parseAbi([
     "function setTrustedRemoteAddress(uint16 remoteChainId, bytes calldata remoteAddress)"
 ]);
 
+const PROXY_ADMIN_ABI = parseAbi([
+    "function transferOwnership(address)",
+    "function changeProxyAdmin(address proxy, address newAdmin)"
+]);
+
 const V2_FACTORY_ABI = parseAbi([
     "function setFeeToSetter(address)"
 ]);
@@ -21,7 +26,7 @@ const POOL_MANAGER_ABI = parseAbi([
 
 const OP_PORTAL2_ABI = parseAbi([
     "function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)"
-])
+]);
 
 const ETHEREUM = {
     OMNICHAIN_PROPOSAL_SENDER: getAddress("0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc"),
@@ -29,11 +34,16 @@ const ETHEREUM = {
 
 const MEGA = {
     OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress("0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c"),
+    OMNICHAIN_GOVERNANCE_EXECUTOR_2: getAddress("0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9"),
     LZ_ENDPOINT: getAddress("0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7"),
     WORMHOLE_RECEIVER: getAddress("0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB"),
     V2_FACTORY: getAddress("0xbf56488c857A881ae7e3BED27Cf99c10A7Ab7e50"),
     V3_FACTORY: getAddress("0x3a5F0CD7d62452b7f899B2A5758BFa57be0dE478"),
     POOL_MANAGER: getAddress("0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E"),
+    V3_PROXY_ADMIN: getAddress("0xdaFBcEB5cA32Dc1DD27A413dA361F32636694BC4"),
+    V4_PROXY_ADMIN: getAddress("0x07e7c1cEd961e2C11196751A1aC76E64b0e8b007"),
+    V3_POSITION_DESCRIPTOR: getAddress("0x8D9F62d363486ebadD3F3d735301a99a487a8fD8"),
+    V4_POSITION_DESCRIPTOR: getAddress("0xA9fDbB9D3dce2e1cFB91c4AF1B8Cf4ed62c0041A"),
 };
 
 const AVAX = {
@@ -43,6 +53,10 @@ const AVAX = {
     V2_FACTORY: getAddress("0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
     V3_FACTORY: getAddress("0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD"),
     POOL_MANAGER: getAddress("0x06380C0e0912312B5150364B9DC4542BA0DbBc85"),
+    V3_PROXY_ADMIN: getAddress("0x9AdA7D7879214073F40183F3410F2b3f088c6381"),
+    V4_PROXY_ADMIN: getAddress("0x9b0481d2A2912051f56dC0B806cafe6bdE461c3D"),
+    V3_POSITION_DESCRIPTOR: getAddress("0xE1f93a7cB6fFa2dB4F9d5A2FD43158A428993C09"),
+    V4_POSITION_DESCRIPTOR: getAddress("0x2b1AED9445B05AC1A3B203eCCC1e25dD9351F0A9"),
 };
 
 const SONEIUM = {
@@ -63,9 +77,9 @@ const LZ_AVAX_CHAIN_ID = 106;
 const LZ_MEGA_CHAIN_ID = 398;
 
 // -------------------------------------------------------------------------------------------------
-// 01: Finalize Layer Zero Configuration for MegaEth
+// NN: (Ethereum) Set Layer Zero Trusted Remote For Mega
 //
-const ethSetTrustedRemoteToMega = {
+const ethSetTrustedRemoteToMega0x88 = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
     value: 0n,
     signature: "",
@@ -80,40 +94,50 @@ const ethSetTrustedRemoteToMega = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 02: Transfer Ownership on MegaETH from Layer Zero to Wormhole
+// NN: (Mega) Transfer Ownership on MegaETH from Layer Zero to Wormhole
 //
-const lzCallsOnMega = {
-    v2SetFeeToSetter: {
+const megaLzTransferOwnershipCalls = [
+    {
         target: MEGA.V2_FACTORY,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: V2_FACTORY_ABI,
             functionName: "setFeeToSetter",
             args: [MEGA.WORMHOLE_RECEIVER]
         })
     },
-    v3SetOwner: {
+    {
         target: MEGA.V3_FACTORY,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: V3_FACTORY_ABI,
             functionName: "setOwner",
             args: [MEGA.WORMHOLE_RECEIVER]
         })
     },
-    poolManagerTransferOwnership: {
+    {
         target: MEGA.POOL_MANAGER,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: POOL_MANAGER_ABI,
             functionName: "transferOwnership",
             args: [MEGA.WORMHOLE_RECEIVER]
         })
     },
-};
+    {
+        target: MEGA.V4_PROXY_ADMIN,
+        value: 0n,
+        signature: "",
+        calldata: encodeFunctionData({
+            abi: PROXY_ADMIN_ABI,
+            functionName: "transferOwnership",
+            args: [MEGA.WORMHOLE_RECEIVER]
+        })
+    },
+];
 
 const megaTransferOwnershipFromLzToWormhole = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
@@ -127,26 +151,10 @@ const megaTransferOwnershipFromLzToWormhole = {
             encodeAbiParameters(
                 parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
                 [
-                    [
-                        lzCallsOnMega.v2SetFeeToSetter.target,
-                        lzCallsOnMega.v3SetOwner.target,
-                        lzCallsOnMega.poolManagerTransferOwnership.target,
-                    ],
-                    [
-                        lzCallsOnMega.v2SetFeeToSetter.value,
-                        lzCallsOnMega.v3SetOwner.value,
-                        lzCallsOnMega.poolManagerTransferOwnership.value,
-                    ],
-                    [
-                        lzCallsOnMega.v2SetFeeToSetter.signature,
-                        lzCallsOnMega.v3SetOwner.signature,
-                        lzCallsOnMega.poolManagerTransferOwnership.signature,
-                    ],
-                    [
-                        lzCallsOnMega.v2SetFeeToSetter.data,
-                        lzCallsOnMega.v3SetOwner.data,
-                        lzCallsOnMega.poolManagerTransferOwnership.data,
-                    ],
+                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.target),
+                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.value),
+                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.signature),
+                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.calldata),
                 ]
             ),
             "0x"
@@ -155,42 +163,67 @@ const megaTransferOwnershipFromLzToWormhole = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 03: Transfer Ownership on Avax from Layer Zero to Wormhole
+// NN: Transfer Ownership on Avax from Layer Zero to Wormhole
 //
-const lzCallsOnAvax = {
-    v2SetFeeToSetter: {
+const avaxLzTransferOwnershipCalls = [
+        {
         target: AVAX.V2_FACTORY,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: V2_FACTORY_ABI,
             functionName: "setFeeToSetter",
             args: [AVAX.WORMHOLE_RECEIVER]
         })
     },
-    v3SetOwner: {
+    {
         target: AVAX.V3_FACTORY,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: V3_FACTORY_ABI,
             functionName: "setOwner",
             args: [AVAX.WORMHOLE_RECEIVER]
         })
     },
-    poolManagerTransferOwnership: {
+    {
         target: AVAX.POOL_MANAGER,
         value: 0n,
         signature: "",
-        data: encodeFunctionData({
+        calldata: encodeFunctionData({
             abi: POOL_MANAGER_ABI,
             functionName: "transferOwnership",
             args: [AVAX.WORMHOLE_RECEIVER]
         })
     },
-};
+    {
+        target: AVAX.V3_PROXY_ADMIN,
+        value: 0n,
+        signature: "",
+        calldata: encodeFunctionData({
+            abi: PROXY_ADMIN_ABI,
+            functionName: "changeProxyAdmin",
+            args: [
+                AVAX.V3_POSITION_DESCRIPTOR,
+                AVAX.V4_PROXY_ADMIN,
+            ]
+        })
+    },
+    {
+        target: AVAX.V4_PROXY_ADMIN,
+        value: 0n,
+        signature: "",
+        calldata: encodeFunctionData({
+            abi: PROXY_ADMIN_ABI,
+            functionName: "transferOwnership",
+            args: [
+                AVAX.WORMHOLE_RECEIVER
+            ]
+        })
+    }
+];
 
-const avaxTransferOwnershipFromLzToWormhole = {
+const avaxTransferOwnershipFromLztoWormhole = {
     target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
     value: 0n,
     signature: "",
@@ -202,26 +235,10 @@ const avaxTransferOwnershipFromLzToWormhole = {
             encodeAbiParameters(
                 parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
                 [
-                    [
-                        lzCallsOnAvax.v2SetFeeToSetter.target,
-                        lzCallsOnAvax.v3SetOwner.target,
-                        lzCallsOnAvax.poolManagerTransferOwnership.target,
-                    ],
-                    [
-                        lzCallsOnAvax.v2SetFeeToSetter.value,
-                        lzCallsOnAvax.v3SetOwner.value,
-                        lzCallsOnAvax.poolManagerTransferOwnership.value,
-                    ],
-                    [
-                        lzCallsOnAvax.v2SetFeeToSetter.signature,
-                        lzCallsOnAvax.v3SetOwner.signature,
-                        lzCallsOnAvax.poolManagerTransferOwnership.signature,
-                    ],
-                    [
-                        lzCallsOnAvax.v2SetFeeToSetter.data,
-                        lzCallsOnAvax.v3SetOwner.data,
-                        lzCallsOnAvax.poolManagerTransferOwnership.data,
-                    ],
+                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.target),
+                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.value),
+                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.signature),
+                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.calldata),
                 ]
             ),
             "0x"
@@ -229,9 +246,8 @@ const avaxTransferOwnershipFromLzToWormhole = {
     })
 };
 
-
 // -------------------------------------------------------------------------------------------------
-// 04: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
+// NN: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumV2SetFeeToSetter = {
     target: SONEIUM.OPTIMISM_PORTAL2,
@@ -255,7 +271,7 @@ const soneiumV2SetFeeToSetter = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 05: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
+// NN: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumPoolManagerTransferOwnership = {
     target: SONEIUM.OPTIMISM_PORTAL2,
@@ -303,7 +319,7 @@ const xLayerV2SetFeeToSetter = {
 };
 
 // -------------------------------------------------------------------------------------------------
-// 07: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
+// NN: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
 //
 const xLayerPoolManagerTransferOwnership = {
     target: X_LAYER.OPTIMISM_PORTAL2,
@@ -326,47 +342,79 @@ const xLayerPoolManagerTransferOwnership = {
     })
 };
 
+// -------------------------------------------------------------------------------------------------
+// NN: (Ethereum) Set Layer Zero Trusted Remote For Mega (OPTIONAL)
+//
+const ethSetTrustedRemoteToMega0x55 = {
+    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+        functionName: "setTrustedRemoteAddress",
+        args: [
+            LZ_MEGA_CHAIN_ID,
+            encodePacked(["address"], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR_2])
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// NN: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
+//
+const megaChangeProxyAdmin = {
+    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+        functionName: "execute",
+        args: [
+            LZ_MEGA_CHAIN_ID,
+            encodeAbiParameters(
+                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
+                [
+                    [MEGA.V3_PROXY_ADMIN],
+                    [0n],
+                    [""],
+                    [
+                        encodeFunctionData({
+                            abi: PROXY_ADMIN_ABI,
+                            functionName: "changeProxyAdmin",
+                            args: [
+                                MEGA.V3_POSITION_DESCRIPTOR,
+                                MEGA.V4_PROXY_ADMIN
+                            ]
+                        })
+                    ],
+                ]
+            ),
+            "0x"
+        ]
+    })
+};
+
+const actions = [
+    ethSetTrustedRemoteToMega0x88,
+    megaTransferOwnershipFromLzToWormhole,
+    avaxTransferOwnershipFromLztoWormhole,
+    soneiumV2SetFeeToSetter,
+    soneiumPoolManagerTransferOwnership,
+    xLayerV2SetFeeToSetter,
+    xLayerPoolManagerTransferOwnership,
+    ethSetTrustedRemoteToMega0x55,
+    megaChangeProxyAdmin,
+];
+
 export const config: SimulationConfigNew = {
     type: "new",
     daoName: "Uniswap",
     governorAddress: getAddress("0x408ED6354d4973f66138C91495F2f2FCbd8724C3"),
     governorType: "bravo",
-    targets: [
-        ethSetTrustedRemoteToMega.target,
-        megaTransferOwnershipFromLzToWormhole.target,
-        avaxTransferOwnershipFromLzToWormhole.target,
-        soneiumV2SetFeeToSetter.target,
-        soneiumPoolManagerTransferOwnership.target,
-        xLayerV2SetFeeToSetter.target,
-        xLayerPoolManagerTransferOwnership.target
-    ],
-    values: [
-        ethSetTrustedRemoteToMega.value,
-        megaTransferOwnershipFromLzToWormhole.value,
-        avaxTransferOwnershipFromLzToWormhole.value,
-        soneiumV2SetFeeToSetter.value,
-        soneiumPoolManagerTransferOwnership.value,
-        xLayerV2SetFeeToSetter.value,
-        xLayerPoolManagerTransferOwnership.value
-    ],
-    signatures: [
-        ethSetTrustedRemoteToMega.signature,
-        megaTransferOwnershipFromLzToWormhole.signature,
-        avaxTransferOwnershipFromLzToWormhole.signature,
-        soneiumV2SetFeeToSetter.signature,
-        soneiumPoolManagerTransferOwnership.signature,
-        xLayerV2SetFeeToSetter.signature,
-        xLayerPoolManagerTransferOwnership.signature
-    ],
-    calldatas: [
-        ethSetTrustedRemoteToMega.calldata,
-        megaTransferOwnershipFromLzToWormhole.calldata,
-        avaxTransferOwnershipFromLzToWormhole.calldata,
-        soneiumV2SetFeeToSetter.calldata,
-        soneiumPoolManagerTransferOwnership.calldata,
-        xLayerV2SetFeeToSetter.calldata,
-        xLayerPoolManagerTransferOwnership.calldata
-    ],
+    targets: actions.map(action => action.target),
+    values: actions.map(action => action.value),
+    signatures: actions.map(action => action.signature),
+    calldatas: actions.map(action => action.calldata),
     description: `
 # [RFC] Update Crosschain Governance Parameters for Avalanche, MegaETH, Soneium, and X Layer
 

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -1,75 +1,74 @@
-import { encodeAbiParameters, encodeFunctionData, encodePacked, getAddress, parseAbi, parseAbiParameters } from 'viem';
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  encodePacked,
+  getAddress,
+  parseAbi,
+  parseAbiParameters,
+} from 'viem';
 
-import type { SimulationConfigNew } from "../types";
+import type { SimulationConfigNew } from '../types';
 
 const OMNICHAIN_PROPOSAL_SENDER_ABI = parseAbi([
-    "function execute(uint16 remoteChainId, bytes calldata payload, bytes calldata adapterParams)",
-    "function setTrustedRemoteAddress(uint16 remoteChainId, bytes calldata remoteAddress)"
+  'function execute(uint16 remoteChainId, bytes calldata payload, bytes calldata adapterParams)',
+  'function setTrustedRemoteAddress(uint16 remoteChainId, bytes calldata remoteAddress)',
 ]);
 
-const PROXY_ADMIN_ABI = parseAbi([
-    "function transferOwnership(address)"
-]);
+const PROXY_ADMIN_ABI = parseAbi(['function transferOwnership(address)']);
 
-const V2_FACTORY_ABI = parseAbi([
-    "function setFeeToSetter(address)"
-]);
+const V2_FACTORY_ABI = parseAbi(['function setFeeToSetter(address)']);
 
-const V3_FACTORY_ABI = parseAbi([
-    "function setOwner(address)"
-]);
+const V3_FACTORY_ABI = parseAbi(['function setOwner(address)']);
 
-const POOL_MANAGER_ABI = parseAbi([
-    "function transferOwnership(address)"
-]);
+const POOL_MANAGER_ABI = parseAbi(['function transferOwnership(address)']);
 
 const OP_PORTAL2_ABI = parseAbi([
-    "function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)"
+  'function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)',
 ]);
 
 const ETHEREUM = {
-    OMNICHAIN_PROPOSAL_SENDER: getAddress("0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc"),
+  OMNICHAIN_PROPOSAL_SENDER: getAddress('0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc'),
 };
 
 const MEGA = {
-    OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress("0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c"),
-    OMNICHAIN_GOVERNANCE_EXECUTOR_2: getAddress("0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9"),
-    LZ_ENDPOINT: getAddress("0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7"),
-    WORMHOLE_RECEIVER: getAddress("0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB"),
-    V2_FACTORY: getAddress("0xbf56488c857A881ae7e3BED27Cf99c10A7Ab7e50"),
-    V3_FACTORY: getAddress("0x3a5F0CD7d62452b7f899B2A5758BFa57be0dE478"),
-    POOL_MANAGER: getAddress("0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E"),
-    V3_PROXY_ADMIN: getAddress("0xdaFBcEB5cA32Dc1DD27A413dA361F32636694BC4"),
-    V4_PROXY_ADMIN: getAddress("0x07e7c1cEd961e2C11196751A1aC76E64b0e8b007"),
-    V3_POSITION_DESCRIPTOR: getAddress("0x8D9F62d363486ebadD3F3d735301a99a487a8fD8"),
-    V4_POSITION_DESCRIPTOR: getAddress("0xA9fDbB9D3dce2e1cFB91c4AF1B8Cf4ed62c0041A"),
+  OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress('0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c'),
+  OMNICHAIN_GOVERNANCE_EXECUTOR_2: getAddress('0x51F9629C1e75aF07421E662DBEb2B7dc8deDefd9'),
+  LZ_ENDPOINT: getAddress('0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7'),
+  WORMHOLE_RECEIVER: getAddress('0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB'),
+  V2_FACTORY: getAddress('0xbf56488c857A881ae7e3BED27Cf99c10A7Ab7e50'),
+  V3_FACTORY: getAddress('0x3a5F0CD7d62452b7f899B2A5758BFa57be0dE478'),
+  POOL_MANAGER: getAddress('0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E'),
+  V3_PROXY_ADMIN: getAddress('0xdaFBcEB5cA32Dc1DD27A413dA361F32636694BC4'),
+  V4_PROXY_ADMIN: getAddress('0x07e7c1cEd961e2C11196751A1aC76E64b0e8b007'),
+  V3_POSITION_DESCRIPTOR: getAddress('0x8D9F62d363486ebadD3F3d735301a99a487a8fD8'),
+  V4_POSITION_DESCRIPTOR: getAddress('0xA9fDbB9D3dce2e1cFB91c4AF1B8Cf4ed62c0041A'),
 };
 
 const AVAX = {
-    OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress("0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc"),
-    LZ_ENDPOINT: getAddress("0x3c2269811836af69497E5F486A85D7316753cf62"),
-    WORMHOLE_RECEIVER: getAddress("0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6"),
-    V2_FACTORY: getAddress("0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
-    V3_FACTORY: getAddress("0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD"),
-    POOL_MANAGER: getAddress("0x06380C0e0912312B5150364B9DC4542BA0DbBc85"),
-    V3_PROXY_ADMIN: getAddress("0x9AdA7D7879214073F40183F3410F2b3f088c6381"),
-    V4_PROXY_ADMIN: getAddress("0x9b0481d2A2912051f56dC0B806cafe6bdE461c3D"),
-    V3_POSITION_DESCRIPTOR: getAddress("0xE1f93a7cB6fFa2dB4F9d5A2FD43158A428993C09"),
-    V4_POSITION_DESCRIPTOR: getAddress("0x2b1AED9445B05AC1A3B203eCCC1e25dD9351F0A9"),
+  OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress('0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc'),
+  LZ_ENDPOINT: getAddress('0x3c2269811836af69497E5F486A85D7316753cf62'),
+  WORMHOLE_RECEIVER: getAddress('0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6'),
+  V2_FACTORY: getAddress('0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C'),
+  V3_FACTORY: getAddress('0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD'),
+  POOL_MANAGER: getAddress('0x06380C0e0912312B5150364B9DC4542BA0DbBc85'),
+  V3_PROXY_ADMIN: getAddress('0x9AdA7D7879214073F40183F3410F2b3f088c6381'),
+  V4_PROXY_ADMIN: getAddress('0x9b0481d2A2912051f56dC0B806cafe6bdE461c3D'),
+  V3_POSITION_DESCRIPTOR: getAddress('0xE1f93a7cB6fFa2dB4F9d5A2FD43158A428993C09'),
+  V4_POSITION_DESCRIPTOR: getAddress('0x2b1AED9445B05AC1A3B203eCCC1e25dD9351F0A9'),
 };
 
 const SONEIUM = {
-    V2_FACTORY: getAddress("0x97FeBbC2AdBD5644ba22736E962564B23F5828CE"),
-    POOL_MANAGER: getAddress("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
-    OPTIMISM_PORTAL2: getAddress("0x88e529A6ccd302c948689Cd5156C83D4614FAE92"),
-    CROSS_CHAIN_ACCOUNT: getAddress("0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7"),
+  V2_FACTORY: getAddress('0x97FeBbC2AdBD5644ba22736E962564B23F5828CE'),
+  POOL_MANAGER: getAddress('0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32'),
+  OPTIMISM_PORTAL2: getAddress('0x88e529A6ccd302c948689Cd5156C83D4614FAE92'),
+  CROSS_CHAIN_ACCOUNT: getAddress('0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7'),
 };
 
 const X_LAYER = {
-    V2_FACTORY: getAddress("0xDf38F24fE153761634Be942F9d859f3DBA857E95"),
-    POOL_MANAGER: getAddress("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
-    OPTIMISM_PORTAL2: getAddress("0x64057ad1DdAc804d0D26A7275b193D9DACa19993"),
-    CROSS_CHAIN_ACCOUNT: getAddress("0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7"),
+  V2_FACTORY: getAddress('0xDf38F24fE153761634Be942F9d859f3DBA857E95'),
+  POOL_MANAGER: getAddress('0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32'),
+  OPTIMISM_PORTAL2: getAddress('0x64057ad1DdAc804d0D26A7275b193D9DACa19993'),
+  CROSS_CHAIN_ACCOUNT: getAddress('0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7'),
 };
 
 const LZ_AVAX_CHAIN_ID = 106;
@@ -81,340 +80,334 @@ const FLAT_LAYER_ZERO_FEE = BigInt(0.01 * 1e18);
 // 00: (Ethereum) Set Layer Zero Trusted Remote For Mega
 //
 const ethSetTrustedRemoteToMega0x88 = {
-    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
-        functionName: "setTrustedRemoteAddress",
-        args: [
-            LZ_MEGA_CHAIN_ID,
-            encodePacked(["address"], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR])
-        ]
-    })
+  target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+    functionName: 'setTrustedRemoteAddress',
+    args: [LZ_MEGA_CHAIN_ID, encodePacked(['address'], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR])],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 01: (Mega) Transfer Ownership on MegaETH from Layer Zero to Wormhole
 //
 const megaLzTransferOwnershipCalls = [
-    {
-        target: MEGA.V2_FACTORY,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: V2_FACTORY_ABI,
-            functionName: "setFeeToSetter",
-            args: [MEGA.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: MEGA.V3_FACTORY,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: V3_FACTORY_ABI,
-            functionName: "setOwner",
-            args: [MEGA.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: MEGA.POOL_MANAGER,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: POOL_MANAGER_ABI,
-            functionName: "transferOwnership",
-            args: [MEGA.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: MEGA.V4_PROXY_ADMIN,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: PROXY_ADMIN_ABI,
-            functionName: "transferOwnership",
-            args: [MEGA.WORMHOLE_RECEIVER]
-        })
-    },
+  {
+    target: MEGA.V2_FACTORY,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: V2_FACTORY_ABI,
+      functionName: 'setFeeToSetter',
+      args: [MEGA.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: MEGA.V3_FACTORY,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: V3_FACTORY_ABI,
+      functionName: 'setOwner',
+      args: [MEGA.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: MEGA.POOL_MANAGER,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: POOL_MANAGER_ABI,
+      functionName: 'transferOwnership',
+      args: [MEGA.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: MEGA.V4_PROXY_ADMIN,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: PROXY_ADMIN_ABI,
+      functionName: 'transferOwnership',
+      args: [MEGA.WORMHOLE_RECEIVER],
+    }),
+  },
 ];
 
 const megaTransferOwnershipFromLzToWormhole = {
-    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: FLAT_LAYER_ZERO_FEE,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
-        functionName: "execute",
-        args: [
-            LZ_MEGA_CHAIN_ID,
-            encodeAbiParameters(
-                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
-                [
-                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.target),
-                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.value),
-                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.signature),
-                    megaLzTransferOwnershipCalls.map(lzCall => lzCall.calldata),
-                ]
-            ),
-            "0x"
-        ]
-    })
+  target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+  value: FLAT_LAYER_ZERO_FEE,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+    functionName: 'execute',
+    args: [
+      LZ_MEGA_CHAIN_ID,
+      encodeAbiParameters(
+        parseAbiParameters(
+          'address[] targets, uint256[] values, string[] signatures, bytes[] datas',
+        ),
+        [
+          megaLzTransferOwnershipCalls.map((lzCall) => lzCall.target),
+          megaLzTransferOwnershipCalls.map((lzCall) => lzCall.value),
+          megaLzTransferOwnershipCalls.map((lzCall) => lzCall.signature),
+          megaLzTransferOwnershipCalls.map((lzCall) => lzCall.calldata),
+        ],
+      ),
+      '0x',
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 02: Transfer Ownership on Avax from Layer Zero to Wormhole
 //
 const avaxLzTransferOwnershipCalls = [
-        {
-        target: AVAX.V2_FACTORY,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: V2_FACTORY_ABI,
-            functionName: "setFeeToSetter",
-            args: [AVAX.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: AVAX.V3_FACTORY,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: V3_FACTORY_ABI,
-            functionName: "setOwner",
-            args: [AVAX.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: AVAX.POOL_MANAGER,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: POOL_MANAGER_ABI,
-            functionName: "transferOwnership",
-            args: [AVAX.WORMHOLE_RECEIVER]
-        })
-    },
-    {
-        target: AVAX.V3_PROXY_ADMIN,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: PROXY_ADMIN_ABI,
-            functionName: "transferOwnership",
-            args: [
-                AVAX.WORMHOLE_RECEIVER
-            ]
-        })
-    },
-    {
-        target: AVAX.V4_PROXY_ADMIN,
-        value: 0n,
-        signature: "",
-        calldata: encodeFunctionData({
-            abi: PROXY_ADMIN_ABI,
-            functionName: "transferOwnership",
-            args: [
-                AVAX.WORMHOLE_RECEIVER
-            ]
-        })
-    }
+  {
+    target: AVAX.V2_FACTORY,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: V2_FACTORY_ABI,
+      functionName: 'setFeeToSetter',
+      args: [AVAX.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: AVAX.V3_FACTORY,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: V3_FACTORY_ABI,
+      functionName: 'setOwner',
+      args: [AVAX.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: AVAX.POOL_MANAGER,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: POOL_MANAGER_ABI,
+      functionName: 'transferOwnership',
+      args: [AVAX.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: AVAX.V3_PROXY_ADMIN,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: PROXY_ADMIN_ABI,
+      functionName: 'transferOwnership',
+      args: [AVAX.WORMHOLE_RECEIVER],
+    }),
+  },
+  {
+    target: AVAX.V4_PROXY_ADMIN,
+    value: 0n,
+    signature: '',
+    calldata: encodeFunctionData({
+      abi: PROXY_ADMIN_ABI,
+      functionName: 'transferOwnership',
+      args: [AVAX.WORMHOLE_RECEIVER],
+    }),
+  },
 ];
 
 const avaxTransferOwnershipFromLztoWormhole = {
-    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: FLAT_LAYER_ZERO_FEE,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
-        functionName: "execute",
-        args: [
-            LZ_AVAX_CHAIN_ID,
-            encodeAbiParameters(
-                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
-                [
-                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.target),
-                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.value),
-                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.signature),
-                    avaxLzTransferOwnershipCalls.map(lzCall => lzCall.calldata),
-                ]
-            ),
-            "0x"
-        ]
-    })
+  target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+  value: FLAT_LAYER_ZERO_FEE,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+    functionName: 'execute',
+    args: [
+      LZ_AVAX_CHAIN_ID,
+      encodeAbiParameters(
+        parseAbiParameters(
+          'address[] targets, uint256[] values, string[] signatures, bytes[] datas',
+        ),
+        [
+          avaxLzTransferOwnershipCalls.map((lzCall) => lzCall.target),
+          avaxLzTransferOwnershipCalls.map((lzCall) => lzCall.value),
+          avaxLzTransferOwnershipCalls.map((lzCall) => lzCall.signature),
+          avaxLzTransferOwnershipCalls.map((lzCall) => lzCall.calldata),
+        ],
+      ),
+      '0x',
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 03: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumV2SetFeeToSetter = {
-    target: SONEIUM.OPTIMISM_PORTAL2,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OP_PORTAL2_ABI,
-        functionName: "depositTransaction",
-        args: [
-            SONEIUM.V2_FACTORY,
-            0n,
-            200_000n,
-            false,
-            encodeFunctionData({
-                abi: V2_FACTORY_ABI,
-                functionName: "setFeeToSetter",
-                args: [SONEIUM.CROSS_CHAIN_ACCOUNT]
-            })
-        ]
-    })
+  target: SONEIUM.OPTIMISM_PORTAL2,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OP_PORTAL2_ABI,
+    functionName: 'depositTransaction',
+    args: [
+      SONEIUM.V2_FACTORY,
+      0n,
+      200_000n,
+      false,
+      encodeFunctionData({
+        abi: V2_FACTORY_ABI,
+        functionName: 'setFeeToSetter',
+        args: [SONEIUM.CROSS_CHAIN_ACCOUNT],
+      }),
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 04: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
 //
 const soneiumPoolManagerTransferOwnership = {
-    target: SONEIUM.OPTIMISM_PORTAL2,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OP_PORTAL2_ABI,
-        functionName: "depositTransaction",
-        args: [
-            SONEIUM.POOL_MANAGER,
-            0n,
-            200_000n,
-            false,
-            encodeFunctionData({
-                abi: POOL_MANAGER_ABI,
-                functionName: "transferOwnership",
-                args: [SONEIUM.CROSS_CHAIN_ACCOUNT]
-            })
-        ]
-    })
+  target: SONEIUM.OPTIMISM_PORTAL2,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OP_PORTAL2_ABI,
+    functionName: 'depositTransaction',
+    args: [
+      SONEIUM.POOL_MANAGER,
+      0n,
+      200_000n,
+      false,
+      encodeFunctionData({
+        abi: POOL_MANAGER_ABI,
+        functionName: 'transferOwnership',
+        args: [SONEIUM.CROSS_CHAIN_ACCOUNT],
+      }),
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 05: Transfer V2 Fee Setter on XLayer from OptimismPortal2 to CrossChainAccount
 //
 const xLayerV2SetFeeToSetter = {
-    target: X_LAYER.OPTIMISM_PORTAL2,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OP_PORTAL2_ABI,
-        functionName: "depositTransaction",
-        args: [
-            X_LAYER.V2_FACTORY,
-            0n,
-            200_000n,
-            false,
-            encodeFunctionData({
-                abi: V2_FACTORY_ABI,
-                functionName: "setFeeToSetter",
-                args: [X_LAYER.CROSS_CHAIN_ACCOUNT]
-            })
-        ]
-    })
+  target: X_LAYER.OPTIMISM_PORTAL2,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OP_PORTAL2_ABI,
+    functionName: 'depositTransaction',
+    args: [
+      X_LAYER.V2_FACTORY,
+      0n,
+      200_000n,
+      false,
+      encodeFunctionData({
+        abi: V2_FACTORY_ABI,
+        functionName: 'setFeeToSetter',
+        args: [X_LAYER.CROSS_CHAIN_ACCOUNT],
+      }),
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 06: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
 //
 const xLayerPoolManagerTransferOwnership = {
-    target: X_LAYER.OPTIMISM_PORTAL2,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OP_PORTAL2_ABI,
-        functionName: "depositTransaction",
-        args: [
-            X_LAYER.POOL_MANAGER,
-            0n,
-            200_000n,
-            false,
-            encodeFunctionData({
-                abi: POOL_MANAGER_ABI,
-                functionName: "transferOwnership",
-                args: [X_LAYER.CROSS_CHAIN_ACCOUNT]
-            })
-        ]
-    })
+  target: X_LAYER.OPTIMISM_PORTAL2,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OP_PORTAL2_ABI,
+    functionName: 'depositTransaction',
+    args: [
+      X_LAYER.POOL_MANAGER,
+      0n,
+      200_000n,
+      false,
+      encodeFunctionData({
+        abi: POOL_MANAGER_ABI,
+        functionName: 'transferOwnership',
+        args: [X_LAYER.CROSS_CHAIN_ACCOUNT],
+      }),
+    ],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 07: (Ethereum) Set Layer Zero Trusted Remote For Mega (OPTIONAL)
 //
 const ethSetTrustedRemoteToMega0x55 = {
-    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: 0n,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
-        functionName: "setTrustedRemoteAddress",
-        args: [
-            LZ_MEGA_CHAIN_ID,
-            encodePacked(["address"], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR_2])
-        ]
-    })
+  target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+  value: 0n,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+    functionName: 'setTrustedRemoteAddress',
+    args: [LZ_MEGA_CHAIN_ID, encodePacked(['address'], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR_2])],
+  }),
 };
 
 // -------------------------------------------------------------------------------------------------
 // 08: (Mega) Change ProxyAdmin for NonfungiblePositionDescriptor (OPTIONAL)
 //
 const megaTransferProxyAdminOwnership = {
-    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
-    value: FLAT_LAYER_ZERO_FEE,
-    signature: "",
-    calldata: encodeFunctionData({
-        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
-        functionName: "execute",
-        args: [
-            LZ_MEGA_CHAIN_ID,
-            encodeAbiParameters(
-                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
-                [
-                    [MEGA.V3_PROXY_ADMIN],
-                    [0n],
-                    [""],
-                    [
-                        encodeFunctionData({
-                            abi: PROXY_ADMIN_ABI,
-                            functionName: "transferOwnership",
-                            args: [
-                                AVAX.WORMHOLE_RECEIVER
-                            ]
-                        })
-                    ],
-                ]
-            ),
-            "0x"
-        ]
-    })
+  target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+  value: FLAT_LAYER_ZERO_FEE,
+  signature: '',
+  calldata: encodeFunctionData({
+    abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+    functionName: 'execute',
+    args: [
+      LZ_MEGA_CHAIN_ID,
+      encodeAbiParameters(
+        parseAbiParameters(
+          'address[] targets, uint256[] values, string[] signatures, bytes[] datas',
+        ),
+        [
+          [MEGA.V3_PROXY_ADMIN],
+          [0n],
+          [''],
+          [
+            encodeFunctionData({
+              abi: PROXY_ADMIN_ABI,
+              functionName: 'transferOwnership',
+              args: [AVAX.WORMHOLE_RECEIVER],
+            }),
+          ],
+        ],
+      ),
+      '0x',
+    ],
+  }),
 };
 
 const actions = [
-    ethSetTrustedRemoteToMega0x88,
-    megaTransferOwnershipFromLzToWormhole,
-    avaxTransferOwnershipFromLztoWormhole,
-    soneiumV2SetFeeToSetter,
-    soneiumPoolManagerTransferOwnership,
-    xLayerV2SetFeeToSetter,
-    xLayerPoolManagerTransferOwnership,
-    ethSetTrustedRemoteToMega0x55,
-    megaTransferProxyAdminOwnership,
+  ethSetTrustedRemoteToMega0x88,
+  megaTransferOwnershipFromLzToWormhole,
+  avaxTransferOwnershipFromLztoWormhole,
+  soneiumV2SetFeeToSetter,
+  soneiumPoolManagerTransferOwnership,
+  xLayerV2SetFeeToSetter,
+  xLayerPoolManagerTransferOwnership,
+  ethSetTrustedRemoteToMega0x55,
+  megaTransferProxyAdminOwnership,
 ];
 
 export const config: SimulationConfigNew = {
-    type: "new",
-    daoName: "Uniswap",
-    governorAddress: getAddress("0x408ED6354d4973f66138C91495F2f2FCbd8724C3"),
-    governorType: "bravo",
-    targets: actions.map(action => action.target),
-    values: actions.map(action => action.value),
-    signatures: actions.map(action => action.signature),
-    calldatas: actions.map(action => action.calldata),
-    description: `
+  type: 'new',
+  daoName: 'Uniswap',
+  governorAddress: getAddress('0x408ED6354d4973f66138C91495F2f2FCbd8724C3'),
+  governorType: 'bravo',
+  targets: actions.map((action) => action.target),
+  values: actions.map((action) => action.value),
+  signatures: actions.map((action) => action.signature),
+  calldatas: actions.map((action) => action.calldata),
+  description: `
     # [RFC] Update Crosschain Governance Parameters for Avalanche, MegaETH, Soneium, and X Layer
 
 ## Summary
@@ -535,5 +528,5 @@ Regarding CrossChainAccount: The low level OP-stack chain bridge uses OptimismPo
 * [LayerZero v1 deprecation announcement](https://layerzero.network/blog/ongoing-security-updates)
 
 * [Original Avalanche deployment proposal](https://gov.uniswap.org/t/deploy-uniswap-v3-on-avalanche/20587)
-`
+`,
 };

--- a/sims/98.sim.ts
+++ b/sims/98.sim.ts
@@ -1,0 +1,491 @@
+import { encodeAbiParameters, encodeFunctionData, encodePacked, getAddress, parseAbi, parseAbiParameter, parseAbiParameters, parseEther, parseGwei, toBytes } from 'viem';
+
+import type { SimulationConfigNew } from "../types";
+
+const OMNICHAIN_PROPOSAL_SENDER_ABI = parseAbi([
+    "function execute(uint16 remoteChainId, bytes calldata payload, bytes calldata adapterParams)",
+    "function setTrustedRemoteAddress(uint16 remoteChainId, bytes calldata remoteAddress)"
+]);
+
+const V2_FACTORY_ABI = parseAbi([
+    "function setFeeToSetter(address)"
+]);
+
+const V3_FACTORY_ABI = parseAbi([
+    "function setOwner(address)"
+]);
+
+const POOL_MANAGER_ABI = parseAbi([
+    "function transferOwnership(address)"
+]);
+
+const OP_PORTAL2_ABI = parseAbi([
+    "function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)"
+])
+
+const ETHEREUM = {
+    OMNICHAIN_PROPOSAL_SENDER: getAddress("0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc"),
+};
+
+const MEGA = {
+    OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress("0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c"),
+    LZ_ENDPOINT: getAddress("0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7"),
+    WORMHOLE_RECEIVER: getAddress("0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB"),
+    V2_FACTORY: getAddress("0xbf56488c857A881ae7e3BED27Cf99c10A7Ab7e50"),
+    V3_FACTORY: getAddress("0x3a5F0CD7d62452b7f899B2A5758BFa57be0dE478"),
+    POOL_MANAGER: getAddress("0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E"),
+};
+
+const AVAX = {
+    OMNICHAIN_GOVERNANCE_EXECUTOR: getAddress("0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc"),
+    LZ_ENDPOINT: getAddress("0x3c2269811836af69497E5F486A85D7316753cf62"),
+    WORMHOLE_RECEIVER: getAddress("0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6"),
+    V2_FACTORY: getAddress("0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C"),
+    V3_FACTORY: getAddress("0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD"),
+    POOL_MANAGER: getAddress("0x06380C0e0912312B5150364B9DC4542BA0DbBc85"),
+};
+
+const SONEIUM = {
+    V2_FACTORY: getAddress("0x97FeBbC2AdBD5644ba22736E962564B23F5828CE"),
+    POOL_MANAGER: getAddress("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
+    OPTIMISM_PORTAL2: getAddress("0x88e529A6ccd302c948689Cd5156C83D4614FAE92"),
+    CROSS_CHAIN_ACCOUNT: getAddress("0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7"),
+};
+
+const X_LAYER = {
+    V2_FACTORY: getAddress("0xDf38F24fE153761634Be942F9d859f3DBA857E95"),
+    POOL_MANAGER: getAddress("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
+    OPTIMISM_PORTAL2: getAddress("0x64057ad1DdAc804d0D26A7275b193D9DACa19993"),
+    CROSS_CHAIN_ACCOUNT: getAddress("0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7"),
+};
+
+const LZ_AVAX_CHAIN_ID = 106;
+const LZ_MEGA_CHAIN_ID = 398;
+
+// -------------------------------------------------------------------------------------------------
+// 01: Finalize Layer Zero Configuration for MegaEth
+//
+const ethSetTrustedRemoteToMega = {
+    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+        functionName: "setTrustedRemoteAddress",
+        args: [
+            LZ_MEGA_CHAIN_ID,
+            encodePacked(["address"], [MEGA.OMNICHAIN_GOVERNANCE_EXECUTOR])
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// 02: Transfer Ownership on MegaETH from Layer Zero to Wormhole
+//
+const lzCallsOnMega = {
+    v2SetFeeToSetter: {
+        target: MEGA.V2_FACTORY,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: V2_FACTORY_ABI,
+            functionName: "setFeeToSetter",
+            args: [MEGA.WORMHOLE_RECEIVER]
+        })
+    },
+    v3SetOwner: {
+        target: MEGA.V3_FACTORY,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: V3_FACTORY_ABI,
+            functionName: "setOwner",
+            args: [MEGA.WORMHOLE_RECEIVER]
+        })
+    },
+    poolManagerTransferOwnership: {
+        target: MEGA.POOL_MANAGER,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: POOL_MANAGER_ABI,
+            functionName: "transferOwnership",
+            args: [MEGA.WORMHOLE_RECEIVER]
+        })
+    },
+};
+
+const megaTransferOwnershipFromLzToWormhole = {
+    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+        functionName: "execute",
+        args: [
+            LZ_MEGA_CHAIN_ID,
+            encodeAbiParameters(
+                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
+                [
+                    [
+                        lzCallsOnMega.v2SetFeeToSetter.target,
+                        lzCallsOnMega.v3SetOwner.target,
+                        lzCallsOnMega.poolManagerTransferOwnership.target,
+                    ],
+                    [
+                        lzCallsOnMega.v2SetFeeToSetter.value,
+                        lzCallsOnMega.v3SetOwner.value,
+                        lzCallsOnMega.poolManagerTransferOwnership.value,
+                    ],
+                    [
+                        lzCallsOnMega.v2SetFeeToSetter.signature,
+                        lzCallsOnMega.v3SetOwner.signature,
+                        lzCallsOnMega.poolManagerTransferOwnership.signature,
+                    ],
+                    [
+                        lzCallsOnMega.v2SetFeeToSetter.data,
+                        lzCallsOnMega.v3SetOwner.data,
+                        lzCallsOnMega.poolManagerTransferOwnership.data,
+                    ],
+                ]
+            ),
+            "0x"
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// 03: Transfer Ownership on Avax from Layer Zero to Wormhole
+//
+const lzCallsOnAvax = {
+    v2SetFeeToSetter: {
+        target: AVAX.V2_FACTORY,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: V2_FACTORY_ABI,
+            functionName: "setFeeToSetter",
+            args: [AVAX.WORMHOLE_RECEIVER]
+        })
+    },
+    v3SetOwner: {
+        target: AVAX.V3_FACTORY,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: V3_FACTORY_ABI,
+            functionName: "setOwner",
+            args: [AVAX.WORMHOLE_RECEIVER]
+        })
+    },
+    poolManagerTransferOwnership: {
+        target: AVAX.POOL_MANAGER,
+        value: 0n,
+        signature: "",
+        data: encodeFunctionData({
+            abi: POOL_MANAGER_ABI,
+            functionName: "transferOwnership",
+            args: [AVAX.WORMHOLE_RECEIVER]
+        })
+    },
+};
+
+const avaxTransferOwnershipFromLzToWormhole = {
+    target: ETHEREUM.OMNICHAIN_PROPOSAL_SENDER,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OMNICHAIN_PROPOSAL_SENDER_ABI,
+        functionName: "execute",
+        args: [
+            LZ_AVAX_CHAIN_ID,
+            encodeAbiParameters(
+                parseAbiParameters("address[] targets, uint256[] values, string[] signatures, bytes[] datas"),
+                [
+                    [
+                        lzCallsOnAvax.v2SetFeeToSetter.target,
+                        lzCallsOnAvax.v3SetOwner.target,
+                        lzCallsOnAvax.poolManagerTransferOwnership.target,
+                    ],
+                    [
+                        lzCallsOnAvax.v2SetFeeToSetter.value,
+                        lzCallsOnAvax.v3SetOwner.value,
+                        lzCallsOnAvax.poolManagerTransferOwnership.value,
+                    ],
+                    [
+                        lzCallsOnAvax.v2SetFeeToSetter.signature,
+                        lzCallsOnAvax.v3SetOwner.signature,
+                        lzCallsOnAvax.poolManagerTransferOwnership.signature,
+                    ],
+                    [
+                        lzCallsOnAvax.v2SetFeeToSetter.data,
+                        lzCallsOnAvax.v3SetOwner.data,
+                        lzCallsOnAvax.poolManagerTransferOwnership.data,
+                    ],
+                ]
+            ),
+            "0x"
+        ]
+    })
+};
+
+
+// -------------------------------------------------------------------------------------------------
+// 04: Transfer V2 Fee Setter on Soneium from OptimismPortal2 to CrossChainAccount
+//
+const soneiumV2SetFeeToSetter = {
+    target: SONEIUM.OPTIMISM_PORTAL2,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OP_PORTAL2_ABI,
+        functionName: "depositTransaction",
+        args: [
+            SONEIUM.V2_FACTORY,
+            0n,
+            200_000n,
+            false,
+            encodeFunctionData({
+                abi: V2_FACTORY_ABI,
+                functionName: "setFeeToSetter",
+                args: [SONEIUM.CROSS_CHAIN_ACCOUNT]
+            })
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// 05: Transfer V4 Ownership on Soneium from OptimismPortal2 to CrossChainAccount
+//
+const soneiumPoolManagerTransferOwnership = {
+    target: SONEIUM.OPTIMISM_PORTAL2,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OP_PORTAL2_ABI,
+        functionName: "depositTransaction",
+        args: [
+            SONEIUM.POOL_MANAGER,
+            0n,
+            200_000n,
+            false,
+            encodeFunctionData({
+                abi: POOL_MANAGER_ABI,
+                functionName: "transferOwnership",
+                args: [SONEIUM.CROSS_CHAIN_ACCOUNT]
+            })
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// 06: Transfer V2 Fee Setter on XLayer from OptimismPortal2 to CrossChainAccount
+//
+const xLayerV2SetFeeToSetter = {
+    target: X_LAYER.OPTIMISM_PORTAL2,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OP_PORTAL2_ABI,
+        functionName: "depositTransaction",
+        args: [
+            X_LAYER.V2_FACTORY,
+            0n,
+            200_000n,
+            false,
+            encodeFunctionData({
+                abi: V2_FACTORY_ABI,
+                functionName: "setFeeToSetter",
+                args: [X_LAYER.CROSS_CHAIN_ACCOUNT]
+            })
+        ]
+    })
+};
+
+// -------------------------------------------------------------------------------------------------
+// 07: Transfer V4 Ownership on XLayer from OptimismPortal2 to CrossChainAccount
+//
+const xLayerPoolManagerTransferOwnership = {
+    target: X_LAYER.OPTIMISM_PORTAL2,
+    value: 0n,
+    signature: "",
+    calldata: encodeFunctionData({
+        abi: OP_PORTAL2_ABI,
+        functionName: "depositTransaction",
+        args: [
+            X_LAYER.POOL_MANAGER,
+            0n,
+            200_000n,
+            false,
+            encodeFunctionData({
+                abi: POOL_MANAGER_ABI,
+                functionName: "transferOwnership",
+                args: [X_LAYER.CROSS_CHAIN_ACCOUNT]
+            })
+        ]
+    })
+};
+
+export const config: SimulationConfigNew = {
+    type: "new",
+    daoName: "Uniswap",
+    governorAddress: getAddress("0x408ED6354d4973f66138C91495F2f2FCbd8724C3"),
+    governorType: "bravo",
+    targets: [
+        ethSetTrustedRemoteToMega.target,
+        megaTransferOwnershipFromLzToWormhole.target,
+        avaxTransferOwnershipFromLzToWormhole.target,
+        soneiumV2SetFeeToSetter.target,
+        soneiumPoolManagerTransferOwnership.target,
+        xLayerV2SetFeeToSetter.target,
+        xLayerPoolManagerTransferOwnership.target
+    ],
+    values: [
+        ethSetTrustedRemoteToMega.value,
+        megaTransferOwnershipFromLzToWormhole.value,
+        avaxTransferOwnershipFromLzToWormhole.value,
+        soneiumV2SetFeeToSetter.value,
+        soneiumPoolManagerTransferOwnership.value,
+        xLayerV2SetFeeToSetter.value,
+        xLayerPoolManagerTransferOwnership.value
+    ],
+    signatures: [
+        ethSetTrustedRemoteToMega.signature,
+        megaTransferOwnershipFromLzToWormhole.signature,
+        avaxTransferOwnershipFromLzToWormhole.signature,
+        soneiumV2SetFeeToSetter.signature,
+        soneiumPoolManagerTransferOwnership.signature,
+        xLayerV2SetFeeToSetter.signature,
+        xLayerPoolManagerTransferOwnership.signature
+    ],
+    calldatas: [
+        ethSetTrustedRemoteToMega.calldata,
+        megaTransferOwnershipFromLzToWormhole.calldata,
+        avaxTransferOwnershipFromLzToWormhole.calldata,
+        soneiumV2SetFeeToSetter.calldata,
+        soneiumPoolManagerTransferOwnership.calldata,
+        xLayerV2SetFeeToSetter.calldata,
+        xLayerPoolManagerTransferOwnership.calldata
+    ],
+    description: `
+# [RFC] Update Crosschain Governance Parameters for Avalanche, MegaETH, Soneium, and X Layer
+
+## Summary
+
+Secure crosschain messaging is an integral part of Uniswap's governance model. Governance votes like protocol fee adjustments are executed by UNI holders on Ethereum Mainnet and must subsequently be relayed to destination chains.
+
+
+
+This proposal updates Uniswap's crosschain governance system to accommodate the latest best practices. Specifically, we propose to:
+
+
+
+* Transition ownership of the Uniswap v2 and v4 contracts on Soneium and X Layer to CrossChainAccount contracts, which we consider to be the current best practice for executing messages from Ethereum Mainnet on the OP Stack
+
+* Migrate the entire messaging system for the Avalanche and MegaETH deployments from LayerZero v1 (part of which is [being deprecated](https://layerzero.network/blog/ongoing-security-updates)) to Wormhole 
+
+
+
+Note that because Uniswap v3 on both Soneium and X Layer is owned by the \`v3OpenFeeAdapter\`, which is owned by the CrossChainAccount, we do not need to change the parameter on v3 on these chains.
+
+
+
+---
+
+## Specification
+
+### Current Configuration - Avalanche and MegaETH
+
+Both chains currently use LayerZero v1 for governance messaging:
+
+| Contract | Chain | Address |
+| :---- | :---- | :---- |
+| OmnichainProposalSender | Ethereum | [0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc](https://etherscan.io/address/0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc) |
+| OmnichainGovernanceExecutor | Avalanche | [0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc](https://snowtrace.io/address/0xeb0BCF27D1Fb4b25e708fBB815c421Aeb51eA9fc) |
+| OmnichainGovernanceExecutor | MegaETH | [0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c](https://explorer.megaeth.com/address/0x8819b86ddF592c3aaAa6f9ec7cE1A0f99FC4322c) |
+
+### Proposed Configuration - Avalanche and MegaETH
+
+The LayerZero contracts are replaced with the Wormhole bridge infrastructure from [uniswapfoundation/Uniswap-Wormhole-Bridge](https://github.com/uniswapfoundation/Uniswap-Wormhole-Bridge):
+
+**UniswapWormholeSender (Ethereum):** The existing sender contract already deployed on mainnet will be reused — no new deployment required. 
+
+**UniswapWormholeReceiver (Avalanche and MegaETH):** Uniswap Labs has deployed new UniswapWormholeReceiver contracts on both chains. This proposal will authorize them as the trusted governance executors for each chain.
+
+| Contract | Chain | Address |
+| :---- | :---- | :---- |
+| UniswapWormholeSender | Ethereum | [0xf5F4496219F31CDCBa6130B5402873624585615a](https://etherscan.io/address/0xf5F4496219F31CDCBa6130B5402873624585615a) |
+| UniswapWormholeReceiver | Avalanche | [0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6](https://snowtrace.io/address/0x47eB0Cf11a1626462Da3C830bCDe64c3F582B5a6) |
+| UniswapWormholeReceiver | MegaETH | [0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB](https://explorer.megaeth.com/address/0xa107580F73BD797Bd8b87Ff24e98346D99F93DdB) |
+
+For a detailed discussion of how Wormhole works, please see [this report](https://uniswap.notion.site/Assessment-dac583c6db1240c7b9d294afd7f18035) by the Uniswap Foundation's Bridge Assessment Committee.
+
+### Current Configuration - Soneium and X Layer
+
+On both chains, the UniswapV2Factory's feeToSetter parameter and the v4 PoolManager's owner parameter are configured as the mainnet Timelock's alias address.
+| Account | Chain | Address |
+| :---- | :---- | :---- |
+| Alias Address | X Layer | [0x2BAD8182C09F50c8318d769245beA52C32Be46CD](https://www.oklink.com/x-layer/evm/address/0x2bad8182c09f50c8318d769245bea52c32be46cd) |
+| Alias Address | Soneium | [0x2BAD8182C09F50c8318d769245beA52C32Be46CD](https://soneium.blockscout.com/address/0x2BAD8182C09F50c8318d769245beA52C32Be46CD) |
+
+### Proposed Configuration - Soneium and X Layer
+
+This proposal will change those parameters to a CrossChainAccount contract deployed by Uniswap Labs.
+| Contract | Chain | Address |
+| :---- | :---- | :---- |
+| CrossChainAccount | X Layer | [0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7](https://www.oklink.com/x-layer/evm/address/0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7) |
+| CrossChainAccount | Soneium | [0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7](https://soneium.blockscout.com/address/0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7?tab=contract) |
+
+### Onchain Proposal Spec
+
+**Pre-proposal** (already completed by Uniswap Labs):
+
+* Deploy \`UniswapWormholeReceiver\` on Avalanche C-Chain, configured with the Wormhole Core Bridge address for Avalanche and the address of the existing UniswapWormholeSender.
+
+* Deploy \`UniswapWormholeReceiver\` on MegaETH, configured with the Wormhole Core Bridge address for MegaETH and the address of the existing UniswapWormholeSender.
+
+* Deploy \`CrossChainAccount\` contracts on Soneium and X Layer
+
+**In this proposal** (executed if the vote passes):
+
+Execute seven actions:
+
+1. Finalize LayerZero configuration on MegaETH
+
+2. Transfer ownership of the protocol on MegaETH from LayerZero to Wormhole 
+
+3. Transfer ownership of the protocol on Avalanche from LayerZero to Wormhole
+
+4. Change v2's \`feeToSetter\` on X Layer from the alias address to the \`CrosschainAccount\`
+
+5. Change v4's \`owner\` on X Layer from the alias address to the \`CrosschainAccount\`
+
+6. Change v2's \`feeToSetter\` on Soneium from the alias address to the \`CrosschainAccount\`
+
+7. Change v4's \`owner\` on Soneium from the alias address to the \`CrosschainAccount\`
+
+
+
+---
+
+## Next Steps / Timeline
+
+* **RFC:** Jun 19, 2026
+
+* **Snapshot:** \~1 week after RFC
+
+* **Onchain vote:** Following Snapshot, per standard governance cadence
+
+---
+
+## Supporting Documents
+
+* [Uniswap Foundation Bridge Assessment Report](https://uniswap.notion.site/Bridge-Assessment-Report-0c8477afadce425abac9c0bd175ca382)
+
+* [Uniswap-Wormhole-Bridge GitHub](https://github.com/uniswapfoundation/Uniswap-Wormhole-Bridge)
+
+* [LayerZero v1 deprecation announcement](https://layerzero.network/blog/ongoing-security-updates)
+
+* [Original Avalanche deployment proposal](https://gov.uniswap.org/t/deploy-uniswap-v3-on-avalanche/20587)
+`
+};

--- a/utils/clients/client.ts
+++ b/utils/clients/client.ts
@@ -52,7 +52,7 @@ export interface ChainConfig {
   rpcUrl: string;
 }
 
-const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL || 'https://cloudflare-eth.com';
+const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL || 'https://ethereum-rpc.publicnode.com';
 const ARBITRUM_RPC_URL = process.env.ARBITRUM_RPC_URL || arbitrum.rpcUrls.default.http[0];
 
 const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;

--- a/utils/clients/tenderly-api.ts
+++ b/utils/clients/tenderly-api.ts
@@ -201,27 +201,112 @@ export async function getLatestBlock(chainId: number): Promise<number> {
   }
 }
 
+// Tenderly's `encode-states` endpoint rejects request bodies above ~11KB with a 413. We keep each
+// chunk comfortably below that cliff. Each storage key encodes to its own independent slot(s), so
+// splitting the overrides across multiple requests and merging the responses is equivalent to a
+// single request. Overridable via env in case the limit differs behind a proxy.
+const DEFAULT_MAX_ENCODE_BODY_BYTES = 8_000;
+const MAX_ENCODE_BODY_BYTES = (() => {
+  const raw = process.env.TENDERLY_ENCODE_MAX_BODY_BYTES;
+  if (!raw) return DEFAULT_MAX_ENCODE_BODY_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `Invalid TENDERLY_ENCODE_MAX_BODY_BYTES="${raw}", using default ${DEFAULT_MAX_ENCODE_BODY_BYTES}`,
+    );
+    return DEFAULT_MAX_ENCODE_BODY_BYTES;
+  }
+  return parsed;
+})();
+
+type EncodeEntry = { address: string; key: string; value: string };
+
+/**
+ * Split a state-overrides payload into chunks whose serialized body stays under
+ * MAX_ENCODE_BODY_BYTES. Every chunk holds at least one entry, even if that entry alone exceeds the
+ * budget (a single oversized value is still far below the endpoint's hard limit).
+ */
+function chunkStateOverrides(payload: StateOverridesPayload): StateOverridesPayload[] {
+  const entries: EncodeEntry[] = [];
+  for (const [address, { value }] of Object.entries(payload.stateOverrides)) {
+    for (const [key, val] of Object.entries(value)) {
+      entries.push({ address, key, value: val });
+    }
+  }
+
+  const chunks: EncodeEntry[][] = [];
+  let current: EncodeEntry[] = [];
+  let currentBytes = 0;
+  // Approximate per-entry serialized cost: "key":"value", plus quotes/colon/comma.
+  const entrySize = (e: EncodeEntry) => e.key.length + e.value.length + 8;
+
+  for (const entry of entries) {
+    const size = entrySize(entry);
+    if (current.length > 0 && currentBytes + size > MAX_ENCODE_BODY_BYTES) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(entry);
+    currentBytes += size;
+  }
+  if (current.length > 0) chunks.push(current);
+
+  return chunks.map((chunkEntries) => {
+    const stateOverrides: StateOverridesPayload['stateOverrides'] = {};
+    for (const { address, key, value } of chunkEntries) {
+      if (!stateOverrides[address]) stateOverrides[address] = { value: {} };
+      stateOverrides[address].value[key] = value;
+    }
+    return { networkID: payload.networkID, stateOverrides };
+  });
+}
+
+function mergeEncodingResponses(responses: StorageEncodingResponse[]): StorageEncodingResponse {
+  const merged: StorageEncodingResponse = { stateOverrides: {} };
+  for (const response of responses) {
+    for (const [address, { value }] of Object.entries(response.stateOverrides)) {
+      const existing = merged.stateOverrides[address];
+      merged.stateOverrides[address] = {
+        ...existing,
+        value: { ...(existing?.value ?? {}), ...value },
+      };
+    }
+  }
+  return merged;
+}
+
+async function sendEncodeChunk(payload: StateOverridesPayload): Promise<StorageEncodingResponse> {
+  const fetchOptions = <Partial<FETCH_OPT>>{
+    method: 'POST',
+    data: payload,
+    ...getTenderlyFetchOptions(),
+  };
+  const rawResponse = await fetchUrlWithTimeout(
+    `Tenderly sendEncodeRequest(${payload.networkID})`,
+    getTenderlyEncodeUrl(),
+    fetchOptions,
+  );
+  return parseWithSchema(
+    tenderlyStorageEncodingSchema,
+    rawResponse,
+    'Tenderly storage encoding response',
+  );
+}
+
 export async function sendEncodeRequest(
   payload: StateOverridesPayload,
 ): Promise<StorageEncodingResponse> {
   try {
-    const fetchOptions = <Partial<FETCH_OPT>>{
-      method: 'POST',
-      data: payload,
-      ...getTenderlyFetchOptions(),
-    };
-    const rawResponse = await fetchUrlWithTimeout(
-      `Tenderly sendEncodeRequest(${payload.networkID})`,
-      getTenderlyEncodeUrl(),
-      fetchOptions,
-    );
-    const response = parseWithSchema(
-      tenderlyStorageEncodingSchema,
-      rawResponse,
-      'Tenderly storage encoding response',
-    );
-
-    return response;
+    const chunks = chunkStateOverrides(payload);
+    if (chunks.length <= 1) {
+      return await sendEncodeChunk(payload);
+    }
+    const responses: StorageEncodingResponse[] = [];
+    for (const chunk of chunks) {
+      responses.push(await sendEncodeChunk(chunk));
+    }
+    return mergeEncodingResponses(responses);
   } catch (err) {
     console.log('logging sendEncodeRequest error');
     console.log(JSON.stringify(err, null, 2));

--- a/utils/contracts/governor.ts
+++ b/utils/contracts/governor.ts
@@ -139,26 +139,18 @@ export async function getProposalIds(
   latestBlockNum: bigint,
 ): Promise<bigint[]> {
   if (governorType === 'bravo') {
-    // Fetch all proposal IDs
     const governor = governorBravo(address);
-    const proposalCreatedEvents = await publicClient.getContractEvents({
-      address: governor.address,
-      abi: GOVERNOR_ABI,
-      eventName: 'ProposalCreated',
-      fromBlock: 0n,
-      toBlock: latestBlockNum,
-    });
+    const [initialProposalId, proposalCount] = await Promise.all([
+      governor.read.initialProposalId(),
+      governor.read.proposalCount(),
+    ]);
 
-    // Get all proposal IDs from events
-    const allProposalIds = proposalCreatedEvents
-      .map((event) => event.args.id)
-      .filter((id): id is bigint => id !== undefined);
+    const proposalIds: bigint[] = [];
+    for (let id = initialProposalId + 1n; id <= proposalCount; id += 1n) {
+      proposalIds.push(id);
+    }
 
-    // Remove proposals from GovernorAlpha based on the initial GovernorBravo proposal ID
-    const initialProposalId = await governor.read.initialProposalId();
-
-    // Filter out those that are less than or equal to initialProposalId
-    return allProposalIds.filter((id) => id > initialProposalId);
+    return proposalIds;
   }
 
   // Fetch all proposal IDs for OZ governor


### PR DESCRIPTION
## Summary
- Mirrors PR #269 onto an org-owned branch so CI can access required Tenderly secrets.
- Adds Proposal 98 simulation support and Tenderly request chunking.
- Keeps the CI fixes needed for public RPC fallback and GovernorBravo proposal IDs.

## Test Plan
- Automated: `bun run typecheck` — validates TypeScript.
- Automated: `bunx biome check sims/98.sim.ts utils/clients/client.ts utils/clients/tenderly-api.ts utils/contracts/governor.ts` — validates changed files.
