### PR TITLE
fix: replace stale local proposal artifact

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { getAddress } from 'viem';
 import { mainnet } from 'viem/chains';
 import { generateAndSaveReports } from './presentation/report';
@@ -54,6 +55,13 @@ interface CliOptions {
 interface DerivedContext {
   executionOptions: SimulationExecutionOptions;
   provenance: DerivedSimulationDependency;
+}
+
+interface ProcessSimulationOptions {
+  provenance?: DerivedSimulationDependency;
+  shouldCache?: boolean;
+  simulationResultsOutputPath?: string;
+  writeReports?: boolean;
 }
 
 function parseCliOptions(argv: string[]): CliOptions {
@@ -231,10 +239,14 @@ async function processSimulation(
   simulationResult: SimulationResult,
   proposalId: string,
   proposalState: string,
-  shouldCache = true,
-  provenance?: DerivedSimulationDependency,
-  writeReports = true,
+  options: ProcessSimulationOptions = {},
 ) {
+  const {
+    provenance,
+    shouldCache = true,
+    simulationResultsOutputPath,
+    writeReports = true,
+  } = options;
   const {
     sim,
     proposal,
@@ -373,6 +385,7 @@ async function processSimulation(
       contracts: sim.contracts,
       proposalState,
       provenance,
+      simulationResultsOutputPath,
     });
   }
 
@@ -462,9 +475,7 @@ async function buildDerivedContext(params: {
     predecessorResult,
     predecessorResult.proposal.id.toString(),
     params.predecessorState,
-    false,
-    undefined,
-    false,
+    { shouldCache: false, writeReports: false },
   );
 
   const outcome = evaluateDependencyOutcome(
@@ -621,8 +632,16 @@ async function main() {
       finalResult,
       proposal.id.toString(),
       'Pending',
-      false,
-      provenance,
+      {
+        provenance,
+        shouldCache: false,
+        simulationResultsOutputPath: join(
+          import.meta.dir,
+          'frontend',
+          'public',
+          'simulation-results.json',
+        ),
+      },
     );
 
     console.log(`[Index] Reports saved for ${label}.`);
@@ -800,8 +819,7 @@ async function main() {
           finalResult,
           simProposal.id.toString(),
           simProposal.state,
-          shouldCacheCanonicalProposal,
-          provenance,
+          { provenance, shouldCache: shouldCacheCanonicalProposal },
         );
 
         simOutputs.push(processed.simulationData);

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, promises as fsp, mkdirSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 import { mdToPdf } from 'md-to-pdf';
 import type { Link, Root } from 'mdast';
 import rehypeSanitize from 'rehype-sanitize';
@@ -1186,7 +1186,7 @@ export function writeSimulationResultsJson(params: WriteSimulationResultsJsonPar
 
 /**
  * Generates the proposal report and saves Markdown, PDF, and HTML versions of it.
- * Also writes the report data to the frontend/public directory for easy access.
+ * Also writes the simulation results to the configured output path.
  * @param blocks the relevant blocks for the proposal.
  * @param proposal The proposal details.
  * @param checks The checks results.
@@ -1215,6 +1215,7 @@ export async function generateAndSaveReports(params: GenerateReportsParams) {
     contracts,
     proposalState,
     provenance,
+    simulationResultsOutputPath,
   } = params;
   console.log(`[Report] Generating report for proposal ${proposal.id} (${proposal.proposalId})`);
   console.log(`[Report] Output directory: ${outputDir}`);
@@ -1347,10 +1348,7 @@ export async function generateAndSaveReports(params: GenerateReportsParams) {
     writeCoverageJson(coverage, outputDir, id);
   }
 
-  // Write simulation results JSON for both SIM_NAME and bulk modes
-  const simulationResultsPath = process.env.SIM_NAME
-    ? join(dirname(__dirname), 'frontend', 'public', 'simulation-results.json') // SIM_NAME mode: frontend directory
-    : `${path}-simulation-results.json`; // Bulk mode: alongside other reports
+  const simulationResultsPath = simulationResultsOutputPath ?? `${path}-simulation-results.json`;
 
   writeSimulationResultsJson({
     governorType,

--- a/tests/simulation-results-metadata.test.ts
+++ b/tests/simulation-results-metadata.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type {
@@ -190,6 +190,28 @@ describe('Simulation Results Metadata', () => {
       expect(data).toHaveProperty('report');
       expect(data.report.structuredReport.metadata.governorAddress).toBe(mockGovernorAddress);
     }
+  });
+
+  test('should replace an existing frontend artifact at an explicit output path', async () => {
+    const frontendPublicDir = join(testOutputDir, 'frontend', 'public');
+    const frontendArtifactPath = join(frontendPublicDir, 'simulation-results.json');
+    mkdirSync(frontendPublicDir, { recursive: true });
+    writeFileSync(frontendArtifactPath, JSON.stringify({ proposalData: { id: 'stale' } }));
+
+    await generateAndSaveReports({
+      governorType: 'bravo',
+      blocks: mockBlocks,
+      proposal: mockProposal,
+      checks: mockChecks,
+      outputDir: testOutputDir,
+      governorAddress: mockGovernorAddress,
+      simulationResultsOutputPath: frontendArtifactPath,
+    });
+
+    const content = readFileSync(frontendArtifactPath, 'utf8');
+    const data = JSON.parse(content);
+    expect(data.proposalData.id).toBe('123');
+    expect(data.proposalData.description).toBe(mockProposal.description);
   });
 
   test('should include coverage section in markdown report when provided', async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -913,6 +913,8 @@ export interface GenerateReportsParams {
   proposalState?: string;
   // Provenance metadata for derived-state simulation chains
   provenance?: DerivedSimulationDependency;
+  // Override bulk output when a local flow should feed the frontend directly
+  simulationResultsOutputPath?: string;
 }
 
 export interface WriteSimulationResultsJsonParams {


### PR DESCRIPTION
## Summary
- Make local simulations explicitly replace the frontend artifact.
- Prevent GovKit runs from showing a proposal left by an earlier simulation.

## Test Plan
- Automated: `bun run check`
- Automated: report regression tests — 8 passed
- Automated: GovKit parser tests — 7 passed
- Manual: seeded a UNI transfer artifact, ran `bun propose --proposal-json tests/fixtures/govkit-proposal.json`, and verified `/api/simulation-results` returned the GovKit target and description